### PR TITLE
check_admin fails  when there exists /etc/sudoers hav

### DIFF
--- a/configure
+++ b/configure
@@ -305,7 +305,7 @@ function check_ipaddr(){
 function check_admin(){
     local primary_ip=${1-${PRIMARY_IP}}
     local current_user=$(whoami)
-    if ssh -o "StrictHostKeyChecking no" ${primary_ip} 'sudo -n ls' 1>/dev/null 2>/dev/null; then
+    if ssh -t -o "StrictHostKeyChecking no" ${primary_ip} 'sudo -n ls' 1>/dev/null 2>/dev/null; then
         log_info "admin = ${current_user}@${primary_ip} ok"
     else
         log_error "admin = ${current_user}@${primary_ip} failed"


### PR DESCRIPTION
check_admin fails  when there exists `Defaults requiretty`  in /etc/sudoers .

![image](https://user-images.githubusercontent.com/6322274/131299985-7cb64068-f804-4747-8698-7991de6137a5.png)
