### PR TITLE
Add SSL support for dcs, patroni, postgres & pgbouncer

### DIFF
--- a/files/conf/pigsty-auto.yml
+++ b/files/conf/pigsty-auto.yml
@@ -105,13 +105,14 @@ all:
       # all_proxy:   # set your proxy here: e.g http://user:pass@proxy.xxx.com
 
     #-----------------------------------------------------------------
-    # CA
+    # CA & CERTS
     #-----------------------------------------------------------------
+    cert_homedir: /data/certs         # certs directory
     ca_method: create                 # create|copy|recreate
-    ca_subject: "/CN=root-ca"         # self-signed CA subject
-    ca_homedir: /ca                   # ca cert directory
-    ca_cert: ca.crt                   # ca public key/cert
-    ca_key: ca.key                    # ca private key
+    ca_cn: root-ca                    # CA common name
+    ca_file: ca                       # CA filename
+    ca_validity: 7200d                # CA validity, default is 20 years
+    cert_validity: 3650d              # cert validity, default is 10 years
 
     #-----------------------------------------------------------------
     # NGINX
@@ -336,6 +337,8 @@ all:
     dcs_registry: consul              # where to register services: none | consul | etcd | both
     dcs_safeguard: false              # if true, running dcs will NOT be removed
     dcs_clean: false                  # if true, running dcs will be purged during node init, DANGEROUS
+    dcs_gid: 980                      # gid for consul/etcd users
+    dcs_ssl_enabled: false            # secure dcs communications
 
     #-----------------------------------------------------------------
     # CONSUL
@@ -550,11 +553,13 @@ all:
     pg_namespace: /pg                     # top level key namespace in dcs
     patroni_port: 8008                    # default patroni port
     patroni_log_dir: /pg/log              # patroni log dir, default is /pg/log
+    patroni_ssl_enabled: false            # secure patroni communications
     patroni_watchdog_mode: automatic      # watchdog mode: off|automatic|required
     pg_conf: tiny.yml                     # pgsql template:  {oltp|olap|crit|tiny}.yml
     pg_libs: 'timescaledb, pg_stat_statements, auto_explain'  # extensions to be loaded
     pg_delay: 0                           # apply delay for standby cluster leader
     pg_checksum: false                    # enable data checksum by default
+    pg_sslmode: disable                   # enable sslmode: disable|allow|prefer|require|verify-ca|verify-full
     pg_encoding: UTF8                     # database cluster encoding, UTF8 by default
     pg_locale: C                          # database cluster local, C by default
     pg_lc_collate: C                      # database cluster collate, C by default

--- a/files/conf/pigsty-citus.yml
+++ b/files/conf/pigsty-citus.yml
@@ -125,13 +125,14 @@ all:
       # all_proxy:   # set your proxy here: e.g http://user:pass@proxy.xxx.com
 
     #-----------------------------------------------------------------
-    # CA
+    # CA & CERTS
     #-----------------------------------------------------------------
+    cert_homedir: /data/certs         # certs directory
     ca_method: create                 # create|copy|recreate
-    ca_subject: "/CN=root-ca"         # self-signed CA subject
-    ca_homedir: /ca                   # ca cert directory
-    ca_cert: ca.crt                   # ca public key/cert
-    ca_key: ca.key                    # ca private key
+    ca_cn: root-ca                    # CA common name
+    ca_file: ca                       # CA filename
+    ca_validity: 7200d                # CA validity, default is 20 years
+    cert_validity: 3650d              # cert validity, default is 10 years
 
     #-----------------------------------------------------------------
     # NGINX
@@ -360,6 +361,8 @@ all:
     dcs_registry: consul              # where to register services: none | consul | etcd | both
     dcs_safeguard: false              # if true, running dcs will NOT be removed
     dcs_clean: true                   # if true, running dcs will be purged during node init, DANGEROUS
+    dcs_gid: 980                      # gid for consul/etcd users
+    dcs_ssl_enabled: false            # secure dcs communications
 
     #-----------------------------------------------------------------
     # CONSUL
@@ -593,11 +596,13 @@ all:
     pg_namespace: /pg                     # top level key namespace in dcs
     patroni_port: 8008                    # default patroni port
     patroni_log_dir: /pg/log              # patroni log dir, default is /pg/log
+    patroni_ssl_enabled: false            # secure patroni communications
     patroni_watchdog_mode: automatic      # watchdog mode: off|automatic|required
     pg_conf: tiny.yml                     # pgsql template:  {oltp|olap|crit|tiny}.yml
     pg_libs: 'citus, timescaledb, pg_stat_statements, auto_explain'  # extensions to be loaded
     pg_delay: 0                           # apply delay for standby cluster leader
     pg_checksum: false                    # enable data checksum by default
+    pg_sslmode: disable                   # enable sslmode: disable|allow|prefer|require|verify-ca|verify-full
     pg_encoding: UTF8                     # database cluster encoding, UTF8 by default
     pg_locale: C                          # database cluster local, C by default
     pg_lc_collate: C                      # database cluster collate, C by default

--- a/files/conf/pigsty-dcs3.yml
+++ b/files/conf/pigsty-dcs3.yml
@@ -131,13 +131,14 @@ all:
       # all_proxy:   # set your proxy here: e.g http://user:pass@proxy.xxx.com
 
     #-----------------------------------------------------------------
-    # CA
+    # CA & CERTS
     #-----------------------------------------------------------------
+    cert_homedir: /data/certs         # certs directory
     ca_method: create                 # create|copy|recreate
-    ca_subject: "/CN=root-ca"         # self-signed CA subject
-    ca_homedir: /ca                   # ca cert directory
-    ca_cert: ca.crt                   # ca public key/cert
-    ca_key: ca.key                    # ca private key
+    ca_cn: root-ca                    # CA common name
+    ca_file: ca                       # CA filename
+    ca_validity: 7200d                # CA validity, default is 20 years
+    cert_validity: 3650d              # cert validity, default is 10 years
 
     #-----------------------------------------------------------------
     # NGINX
@@ -367,6 +368,8 @@ all:
     dcs_registry: consul              # where to register services: none | consul | etcd | both
     dcs_safeguard: false              # if true, running dcs will NOT be removed
     dcs_clean: true                   # if true, running dcs will be purged during node init, DANGEROUS
+    dcs_gid: 980                      # gid for consul/etcd users
+    dcs_ssl_enabled: false            # secure dcs communications
 
     #-----------------------------------------------------------------
     # CONSUL
@@ -582,11 +585,13 @@ all:
     pg_namespace: /pg                     # top level key namespace in dcs
     patroni_port: 8008                    # default patroni port
     patroni_log_dir: /pg/log              # patroni log dir, default is /pg/log
+    patroni_ssl_enabled: false            # secure patroni communications
     patroni_watchdog_mode: automatic      # watchdog mode: off|automatic|required
     pg_conf: tiny.yml                     # pgsql template:  {oltp|olap|crit|tiny}.yml
     pg_libs: 'timescaledb, pg_stat_statements, auto_explain'  # extensions to be loaded
     pg_delay: 0                           # apply delay for standby cluster leader
     pg_checksum: false                    # enable data checksum by default
+    pg_sslmode: disable                   # enable sslmode: disable|allow|prefer|require|verify-ca|verify-full
     pg_encoding: UTF8                     # database cluster encoding, UTF8 by default
     pg_locale: C                          # database cluster local, C by default
     pg_lc_collate: C                      # database cluster collate, C by default

--- a/files/conf/pigsty-demo.yml
+++ b/files/conf/pigsty-demo.yml
@@ -222,13 +222,14 @@ all:
       # all_proxy:   # set your proxy here: e.g http://user:pass@proxy.xxx.com
 
     #-----------------------------------------------------------------
-    # CA
+    # CA & CERTS
     #-----------------------------------------------------------------
-    ca_method: create                # create|copy|recreate
-    ca_subject: "/CN=root-ca"        # self-signed CA subject
-    ca_homedir: /ca                  # ca cert directory
-    ca_cert: ca.crt                  # ca public key/cert
-    ca_key: ca.key                   # ca private key
+    cert_homedir: /data/certs         # certs directory
+    ca_method: create                 # create|copy|recreate
+    ca_cn: root-ca                    # CA common name
+    ca_file: ca                       # CA filename
+    ca_validity: 7200d                # CA validity, default is 20 years
+    cert_validity: 3650d              # cert validity, default is 10 years
 
     #-----------------------------------------------------------------
     # NGINX
@@ -476,6 +477,8 @@ all:
     dcs_registry: consul              # where to register services: none | consul | etcd | both
     dcs_safeguard: false              # if true, running dcs will NOT be removed
     dcs_clean: true                   # if true, running dcs will be purged during node init, DANGEROUS
+    dcs_gid: 980                      # gid for consul/etcd users
+    dcs_ssl_enabled: false            # secure dcs communications
 
     #-----------------------------------------------------------------
     # CONSUL
@@ -691,11 +694,13 @@ all:
     pg_namespace: /pg                     # top level key namespace in dcs
     patroni_port: 8008                    # default patroni port
     patroni_log_dir: /pg/log              # patroni log dir, default is /pg/log
+    patroni_ssl_enabled: false            # secure patroni communications
     patroni_watchdog_mode: automatic      # watchdog mode: off|automatic|required
     pg_conf: tiny.yml                     # pgsql template:  {oltp|olap|crit|tiny}.yml
     pg_libs: 'timescaledb, pg_stat_statements, auto_explain'  # extensions to be loaded
     pg_delay: 0                           # apply delay for standby cluster leader
     pg_checksum: false                    # enable data checksum by default
+    pg_sslmode: disable                   # enable sslmode: disable|allow|prefer|require|verify-ca|verify-full
     pg_encoding: UTF8                     # database cluster encoding, UTF8 by default
     pg_locale: C                          # database cluster local, C by default
     pg_lc_collate: C                      # database cluster collate, C by default

--- a/files/conf/pigsty-mxdb.yml
+++ b/files/conf/pigsty-mxdb.yml
@@ -134,13 +134,14 @@ all:
       # all_proxy:   # set your proxy here: e.g http://user:pass@proxy.xxx.com
 
     #-----------------------------------------------------------------
-    # CA
+    # CA & CERTS
     #-----------------------------------------------------------------
+    cert_homedir: /data/certs         # certs directory
     ca_method: create                 # create|copy|recreate
-    ca_subject: "/CN=root-ca"         # self-signed CA subject
-    ca_homedir: /ca                   # ca cert directory
-    ca_cert: ca.crt                   # ca public key/cert
-    ca_key: ca.key                    # ca private key
+    ca_cn: root-ca                    # CA common name
+    ca_file: ca                       # CA filename
+    ca_validity: 7200d                # CA validity, default is 20 years
+    cert_validity: 3650d              # cert validity, default is 10 years
 
     #-----------------------------------------------------------------
     # NGINX
@@ -374,6 +375,8 @@ all:
     dcs_registry: consul              # where to register services: none | consul | etcd | both
     dcs_safeguard: false              # if true, running dcs will NOT be removed
     dcs_clean: true                   # if true, running dcs will be purged during node init, DANGEROUS
+    dcs_gid: 980                      # gid for consul/etcd users
+    dcs_ssl_enabled: false            # secure dcs communications
 
     #-----------------------------------------------------------------
     # CONSUL
@@ -590,11 +593,13 @@ all:
     pg_namespace: /pg                     # top level key namespace in dcs
     patroni_port: 8008                    # default patroni port
     patroni_log_dir: /pg/log              # patroni log dir, default is /pg/log
+    patroni_ssl_enabled: false            # secure patroni communications
     patroni_watchdog_mode: automatic      # watchdog mode: off|automatic|required
     pg_conf: tiny.yml                     # pgsql template:  {oltp|olap|crit|tiny}.yml
     pg_libs: 'timescaledb, pg_stat_statements, auto_explain'  # extensions to be loaded
     pg_delay: 0                           # apply delay for standby cluster leader
     pg_checksum: false                    # enable data checksum by default
+    pg_sslmode: disable                   # enable sslmode: disable|allow|prefer|require|verify-ca|verify-full
     pg_encoding: UTF8                     # database cluster encoding, UTF8 by default
     pg_locale: C                          # database cluster local, C by default
     pg_lc_collate: C                      # database cluster collate, C by default

--- a/files/conf/pigsty-pub4.yml
+++ b/files/conf/pigsty-pub4.yml
@@ -235,13 +235,14 @@ all:
       # all_proxy:   # set your proxy here: e.g http://user:pass@proxy.xxx.com
 
     #-----------------------------------------------------------------
-    # CA
+    # CA & CERTS
     #-----------------------------------------------------------------
-    ca_method: create                # create|copy|recreate
-    ca_subject: "/CN=root-ca"        # self-signed CA subject
-    ca_homedir: /ca                  # ca cert directory
-    ca_cert: ca.crt                  # ca public key/cert
-    ca_key: ca.key                   # ca private key
+    cert_homedir: /data/certs         # certs directory
+    ca_method: create                 # create|copy|recreate
+    ca_cn: root-ca                    # CA common name
+    ca_file: ca                       # CA filename
+    ca_validity: 7200d                # CA validity, default is 20 years
+    cert_validity: 3650d              # cert validity, default is 10 years
 
     #-----------------------------------------------------------------
     # NGINX
@@ -488,6 +489,8 @@ all:
     dcs_registry: consul              # where to register services: none | consul | etcd | both
     dcs_safeguard: false              # if true, running dcs will NOT be removed
     dcs_clean: true                   # if true, running dcs will be purged during node init, DANGEROUS
+    dcs_gid: 980                      # gid for consul/etcd users
+    dcs_ssl_enabled: false            # secure dcs communications
 
     #-----------------------------------------------------------------
     # CONSUL
@@ -703,11 +706,13 @@ all:
     pg_namespace: /pg                     # top level key namespace in dcs
     patroni_port: 8008                    # default patroni port
     patroni_log_dir: /pg/log              # patroni log dir, default is /pg/log
+    patroni_ssl_enabled: false            # secure patroni communications
     patroni_watchdog_mode: automatic      # watchdog mode: off|automatic|required
     pg_conf: tiny.yml                     # pgsql template:  {oltp|olap|crit|tiny}.yml
     pg_libs: 'timescaledb, pg_stat_statements, auto_explain'  # extensions to be loaded
     pg_delay: 0                           # apply delay for standby cluster leader
     pg_checksum: false                    # enable data checksum by default
+    pg_sslmode: disable                   # enable sslmode: disable|allow|prefer|require|verify-ca|verify-full
     pg_encoding: UTF8                     # database cluster encoding, UTF8 by default
     pg_locale: C                          # database cluster local, C by default
     pg_lc_collate: C                      # database cluster collate, C by default

--- a/files/conf/pigsty.yml
+++ b/files/conf/pigsty.yml
@@ -272,13 +272,14 @@ all:
       # all_proxy:   # set your proxy here: e.g http://user:pass@proxy.xxx.com
 
     #-----------------------------------------------------------------
-    # CA
+    # CA & CERTS
     #-----------------------------------------------------------------
+    cert_homedir: /data/certs         # certs directory
     ca_method: create                 # create|copy|recreate
-    ca_subject: "/CN=root-ca"         # self-signed CA subject
-    ca_homedir: /ca                   # ca cert directory
-    ca_cert: ca.crt                   # ca public key/cert
-    ca_key: ca.key                    # ca private key
+    ca_cn: root-ca                    # CA common name
+    ca_file: ca                       # CA filename
+    ca_validity: 7200d                # CA validity, default is 20 years
+    cert_validity: 3650d              # cert validity, default is 10 years
 
     #-----------------------------------------------------------------
     # NGINX
@@ -524,6 +525,8 @@ all:
     dcs_registry: consul              # where to register services: none | consul | etcd | both
     dcs_safeguard: false              # if true, running dcs will NOT be removed
     dcs_clean: true                   # if true, running dcs will be purged during node init, DANGEROUS
+    dcs_gid: 980                      # gid for consul/etcd users
+    dcs_ssl_enabled: false            # secure dcs communications
 
     #-----------------------------------------------------------------
     # CONSUL
@@ -739,11 +742,13 @@ all:
     pg_namespace: /pg                     # top level key namespace in dcs
     patroni_port: 8008                    # default patroni port
     patroni_log_dir: /pg/log              # patroni log dir, default is /pg/log
+    patroni_ssl_enabled: false            # secure patroni communications
     patroni_watchdog_mode: automatic      # watchdog mode: off|automatic|required
     pg_conf: tiny.yml                     # pgsql template:  {oltp|olap|crit|tiny}.yml
     pg_libs: 'timescaledb, pg_stat_statements, auto_explain'  # extensions to be loaded
     pg_delay: 0                           # apply delay for standby cluster leader
     pg_checksum: false                    # enable data checksum by default
+    pg_sslmode: disable                   # enable sslmode: disable|allow|prefer|require|verify-ca|verify-full
     pg_encoding: UTF8                     # database cluster encoding, UTF8 by default
     pg_locale: C                          # database cluster local, C by default
     pg_lc_collate: C                      # database cluster collate, C by default

--- a/infra-demo.yml
+++ b/infra-demo.yml
@@ -75,6 +75,9 @@
     - role: node            # init meta node itself
       tags: [ node , node-init ]
 
+    - role: ca              # init ca-infrastructure
+      tags: ca
+
     - role: docker          # init docker if enabled
       tags: docker
       when: docker_enabled|bool
@@ -97,9 +100,6 @@
   gather_facts: no
   tags: infra
   roles:
-
-    - role: ca              # init ca-infrastructure
-      tags: ca
 
     - role: nameserver    # init dns nameserver
       tags: nameserver

--- a/pigsty.yml
+++ b/pigsty.yml
@@ -272,13 +272,14 @@ all:
       # all_proxy:   # set your proxy here: e.g http://user:pass@proxy.xxx.com
 
     #-----------------------------------------------------------------
-    # CA
+    # CA & CERTS
     #-----------------------------------------------------------------
+    cert_homedir: /data/certs         # certs directory
     ca_method: create                 # create|copy|recreate
-    ca_subject: "/CN=root-ca"         # self-signed CA subject
-    ca_homedir: /ca                   # ca cert directory
-    ca_cert: ca.crt                   # ca public key/cert
-    ca_key: ca.key                    # ca private key
+    ca_cn: root-ca                    # CA common name
+    ca_file: ca                       # CA filename
+    ca_validity: 7200d                # CA validity, default is 20 years
+    cert_validity: 3650d              # cert validity, default is 10 years
 
     #-----------------------------------------------------------------
     # NGINX
@@ -524,6 +525,8 @@ all:
     dcs_registry: consul              # where to register services: none | consul | etcd | both
     dcs_safeguard: false              # if true, running dcs will NOT be removed
     dcs_clean: true                   # if true, running dcs will be purged during node init, DANGEROUS
+    dcs_gid: 980                      # gid for consul/etcd users
+    dcs_ssl_enabled: false            # secure dcs communications
 
     #-----------------------------------------------------------------
     # CONSUL
@@ -739,11 +742,13 @@ all:
     pg_namespace: /pg                     # top level key namespace in dcs
     patroni_port: 8008                    # default patroni port
     patroni_log_dir: /pg/log              # patroni log dir, default is /pg/log
+    patroni_ssl_enabled: false            # secure patroni communications
     patroni_watchdog_mode: automatic      # watchdog mode: off|automatic|required
     pg_conf: tiny.yml                     # pgsql template:  {oltp|olap|crit|tiny}.yml
     pg_libs: 'timescaledb, pg_stat_statements, auto_explain'  # extensions to be loaded
     pg_delay: 0                           # apply delay for standby cluster leader
     pg_checksum: false                    # enable data checksum by default
+    pg_sslmode: disable                   # enable sslmode: disable|allow|prefer|require|verify-ca|verify-full
     pg_encoding: UTF8                     # database cluster encoding, UTF8 by default
     pg_locale: C                          # database cluster local, C by default
     pg_lc_collate: C                      # database cluster collate, C by default

--- a/roles/ca/defaults/main.yml
+++ b/roles/ca/defaults/main.yml
@@ -1,10 +1,11 @@
 ---
 #-----------------------------------------------------------------
-# CA
+# CA & CERTS
 #-----------------------------------------------------------------
-ca_method: create                # create|copy|recreate
-ca_subject: "/CN=root-ca"        # self-signed CA subject
-ca_homedir: /ca                  # ca cert directory
-ca_cert: ca.crt                  # ca public key/cert
-ca_key: ca.key                   # ca private key
+cert_homedir: /data/certs         # certs directory
+ca_method: create                 # create|copy|recreate
+ca_cn: root-ca                    # CA common name
+ca_file: ca                       # CA filename
+ca_validity: 7200d                # CA validity, default is 20 years
+cert_validity: 3650d              # cert validity, default is 10 years
 ...

--- a/roles/ca/tasks/main.yml
+++ b/roles/ca/tasks/main.yml
@@ -3,39 +3,240 @@
 # check ca exists
 #--------------------------------------------------------------------------
 # create repo directory and check cache existence
-- name: Create local ca directory
+- name: Create local cert directory
   tags: ca_dir
-  file: path="{{ ca_homedir }}" state=directory mode=0700
+  file: path="{{ cert_homedir }}" state=directory owner=root group=dcs mode=0755
 
 # if ca_method == copy
 - name: Copy ca cert from local files
   tags: ca_copy
   when: ca_method == 'copy'
-  copy: src={{ item }} dest={{ ca_homedir }}/{{ item }} mode=0600
+  copy: src={{ item }} dest={{ cert_homedir }}/{{ item }} owner=root group=dcs mode=0644
   with_items:
-    - "{{ ca_key }}"
-    - "{{ ca_cert }}"
+    - "{{ ca_file }}.crt"
+    - "{{ ca_file }}.key"
 
+# if ca key exists or explicitly require a new CA
+- name: Check CA exists on tmp
+  tags: ca_check
+  block:
+    - name: Check if ca cert exists
+      stat:
+        path: "{{ cert_homedir }}/{{ ca_file }}.crt"
+      register: ca_crt_exists
+
+    - name: Check if ca key exists
+      stat:
+        path: "{{ cert_homedir }}/{{ ca_file }}.key"
+      register: ca_key_exists
 
 #--------------------------------------------------------------------------
 # create or reuse ca
 #--------------------------------------------------------------------------
-# if ca_method = create, create a self-signed ca key-cert pair if not exists
-# if ca_method = recreate, force recreate a self-signed ca key-cert pair even key-cert already exists
-- name: Check ca key cert exists
+# if ca_method = create, create a self-signed ca keypair if not exists
+# if ca_method = recreate, force recreate a self-signed ca keypair even if already exists
+- name: Create CA certificate
   tags: ca_create
-  when: ca_method == 'create' or ca_method == 'recreate'
-  stat: path={{ ca_homedir }}/{{ ca_key }}
-  register: ca_key_exists
-
-# if ca key not exists or explicitly require a new CA
-- name: Download local repo packages
-  tags: ca_create
-  when: not ca_key_exists.stat.exists or ca_method == 'recreate'
+  when: not (ca_crt_exists.stat.exists and ca_key_exists.stat.exists) or ca_method == 'recreate'
   block:
-    # download from upstream repo
-    - name: Create self-signed CA key-cert
-      command:
-        cmd: openssl req -new -x509 -days 3650 -nodes -out "{{ ca_cert }}" -keyout "{{ ca_key }}" -subj "{{ ca_subject }}"
-        chdir: "{{ ca_homedir }}"
+    - name: Remove existing ca folders
+      file: path="{{ cert_homedir }}" state=absent
+
+    - name: Create certs directory
+      file: path="{{ cert_homedir }}" state=directory owner=root group=dcs mode=0755
+
+    - name: Generate CA private key
+      when: meta_node|bool and pg_role == 'primary'
+      openssl_privatekey:
+        path: "{{ cert_homedir }}/{{ ca_file }}.key"
+        owner: root
+        group: dcs
+        mode: 0644
+
+    - name: Generate CA signing request
+      when: meta_node|bool and pg_role == 'primary'
+      openssl_csr:
+        path: "{{ cert_homedir }}/{{ ca_file }}.csr"
+        privatekey_path: "{{ cert_homedir }}/{{ ca_file }}.key"
+        common_name: "{{ ca_cn }}"
+        use_common_name_for_san: false
+        basic_constraints:
+          - 'CA:TRUE'
+        basic_constraints_critical: yes
+        key_usage:
+          - keyCertSign
+        key_usage_critical: true
+
+    - name: Generate self-signed CA from CSR
+      when: meta_node|bool and pg_role == 'primary'
+      openssl_certificate:
+        path: "{{ cert_homedir }}/{{ ca_file }}.crt"
+        csr_path: "{{ cert_homedir }}/{{ ca_file }}.csr"
+        privatekey_path: "{{ cert_homedir }}/{{ ca_file }}.key"
+        provider: selfsigned
+        selfsigned_not_after: "+{{ ca_validity }}"
+        owner: root
+        group: dcs
+        mode: 0644
+
+
+#--------------------------------------------------------------------------
+# create certs
+#--------------------------------------------------------------------------
+# this cert will be rotated to all meta nodes and can be used for securing meta services
+- name: Create meta certificate for services
+  tags: crt_create
+  when: meta_node|bool and pg_role == 'primary'
+  connection: local
+  delegate_to: localhost
+  block:
+    - name: Generate shared meta private key on primary meta node
+      openssl_privatekey:
+        path: "{{ cert_homedir }}/{{ pg_cluster }}.key"
+        owner: root
+        group: dcs
+        mode: 0644
+
+    - name: Generate shared meta CSR on primary meta node
+      openssl_csr:
+        path: "{{ cert_homedir }}/{{ pg_cluster }}.csr"
+        privatekey_path: "{{ cert_homedir }}/{{ pg_cluster }}.key"
+        common_name: "{{ pg_cluster }}"
+        subject_alt_name: 'DNS:meta'
+
+    - name: Sign shared meta CSR with CA key on primary meta node
+      openssl_certificate:
+        path: "{{ cert_homedir }}/{{ pg_cluster }}.crt"
+        csr_path: "{{ cert_homedir }}/{{ pg_cluster }}.csr"
+        ownca_path: "{{ cert_homedir }}/{{ ca_file }}.crt"
+        ownca_privatekey_path: "{{ cert_homedir }}/{{ ca_file }}.key"
+        provider: ownca
+        selfsigned_not_after: "+{{ cert_validity }}"
+        owner: root
+        group: dcs
+        mode: 0644
+
+# this cert will be rotated to all pg cluster nodes and can be used for securing pg service
+- name: Create pg cluster certificate
+  tags: crt_create
+  when: not meta_node|bool and pg_role == 'primary'
+  connection: local
+  delegate_to: localhost
+  block:
+    - name: Generate pg cluster private key on primary pg node
+      openssl_privatekey:
+        path: "{{ cert_homedir }}/{{ pg_cluster }}.key"
+        owner: root
+        group: dcs
+        mode: 0644
+
+    - name: Generate pg cluster CSR on primary pg node
+      openssl_csr:
+        path: "{{ cert_homedir }}/{{ pg_cluster }}.csr"
+        privatekey_path: "{{ cert_homedir }}/{{ pg_cluster }}.key"
+        common_name: "{{ pg_cluster }}"
+        use_common_name_for_san: false
+
+    - name: Sign pg cluster CSR with CA key on primary pg node
+      openssl_certificate:
+        path: "{{ cert_homedir }}/{{ pg_cluster }}.crt"
+        csr_path: "{{ cert_homedir }}/{{ pg_cluster }}.csr"
+        ownca_path: "{{ cert_homedir }}/{{ ca_file }}.crt"
+        ownca_privatekey_path: "{{ cert_homedir }}/{{ ca_file }}.key"
+        provider: ownca
+        selfsigned_not_after: "+{{ cert_validity }}"
+        owner: root
+        group: dcs
+        mode: 0644
+
+# this cert will be rotated to all infra nodes and can be used for securing infra services (i.e.: consul, etcd..)
+- name: Create nodes certificate
+  connection: local
+  delegate_to: localhost
+  tags: crt_create
+  block:
+    - name: Generate nodes private key
+      openssl_privatekey:
+        path: "{{ cert_homedir }}/{{ pg_cluster }}-{{ pg_seq }}.key"
+        owner: root
+        group: dcs
+        mode: 0644
+
+    - name: Generate nodes signin request
+      openssl_csr:
+        path: "{{ cert_homedir }}/{{ pg_cluster }}-{{ pg_seq }}.csr"
+        privatekey_path: "{{ cert_homedir }}/{{ pg_cluster }}-{{ pg_seq }}.key"
+        common_name: "{{ pg_cluster }}-{{ pg_seq }}"
+        subject_alt_name: "DNS:localhost,DNS:server.{{ dcs_name }}.consul,IP:127.0.0.1,IP:{{ inventory_hostname }}"
+
+    - name: Sign CSRs with CA on primary meta node
+      openssl_certificate:
+        path: "{{ cert_homedir }}/{{ pg_cluster }}-{{ pg_seq }}.crt"
+        csr_path: "{{ cert_homedir }}/{{ pg_cluster }}-{{ pg_seq }}.csr"
+        ownca_path: "{{ cert_homedir }}/{{ ca_file }}.crt"
+        ownca_privatekey_path: "{{ cert_homedir }}/{{ ca_file }}.key"
+        provider: ownca
+        selfsigned_not_after: "+{{ cert_validity }}"
+        owner: root
+        group: dcs
+        mode: 0644
+
+#--------------------------------------------------------------------------
+# copy certs
+#--------------------------------------------------------------------------
+- name: Copy ca certificate on all nodes
+  tags: ca_copy
+  copy: src="{{ cert_homedir }}/{{ ca_file }}.crt" dest="{{ cert_homedir }}/{{ ca_file }}.crt" owner=root group=dcs mode=0644
+
+- name: Copy meta services certificate
+  tags: ca_copy
+  when: meta_node|bool
+  block:
+    - name: Copy shared meta private key on meta nodes
+      copy: src="{{ cert_homedir }}/{{ pg_cluster }}.key" dest="{{ cert_homedir }}/{{ pg_cluster }}.key" owner=root group=dcs mode=0640
+
+    - name: Copy shared meta certificate on meta nodes
+      copy: src="{{ cert_homedir }}/{{ pg_cluster }}.crt" dest="{{ cert_homedir }}/{{ pg_cluster }}.crt" owner=root group=dcs mode=0640
+
+- name: Copy pg cluster certificate
+  tags: ca_copy
+  when: not meta_node|bool
+  block:
+    - name: Copy pg cluster private key on pg nodes
+      copy: src="{{ cert_homedir }}/{{ pg_cluster }}.key" dest="{{ cert_homedir }}/{{ pg_cluster }}.key" owner=root group=dcs mode=0640
+
+    - name: Copy pg cluster certificate on pg nodes
+      copy: src="{{ cert_homedir }}/{{ pg_cluster }}.crt" dest="{{ cert_homedir }}/{{ pg_cluster }}.crt" owner=root group=dcs mode=0640
+
+
+- name: Copy node certificates
+  tags: ca_copy
+  block:
+    - name: Copy node private key
+      tags: ca_copy
+      copy: src="{{ cert_homedir }}/{{ pg_cluster }}-{{ pg_seq }}.key" dest="{{ cert_homedir }}/{{ pg_cluster }}-{{ pg_seq }}.key" owner=root group=dcs mode=0640
+
+    - name: Copy node certificate
+      tags: ca_copy
+      copy: src="{{ cert_homedir }}/{{ pg_cluster }}-{{ pg_seq }}.crt" dest="{{ cert_homedir }}/{{ pg_cluster }}-{{ pg_seq }}.crt" owner=root group=dcs mode=0640
+
+
+#--------------------------------------------------------------------------
+# cleanup % fix permissions
+#--------------------------------------------------------------------------
+- name: Cleanup unnecessary files & fix certs perms
+  tags: crt_cleanup
+  when: meta_node|bool and pg_role == 'primary'
+  block:
+    - name: Cleanup unnecessary files
+      file: path={{ item }} state=absent
+      with_fileglob:
+        - "{{ cert_homedir }}/*.csr"
+
+    - name: Fix certs permissions
+      file: path={{ item }} mode=0640
+      with_fileglob:
+        - "{{ cert_homedir }}/*.crt"
+        - "{{ cert_homedir }}/*.key"
+
 ...

--- a/roles/consul/defaults/main.yml
+++ b/roles/consul/defaults/main.yml
@@ -7,6 +7,8 @@ dcs_servers: { }                  # dcs server dict in name:ip format
 dcs_registry: consul              # where to register services: none | consul | etcd | both
 dcs_safeguard: false              # if true, running dcs will NOT be removed
 dcs_clean: true                   # if true, running dcs will be purged during node init, DANGEROUS
+dcs_gid: 980                      # gid for consul/etcd users
+dcs_ssl_enabled: false            # secure dcs communications
 
 #-----------------------------------------------------------------
 # CONSUL

--- a/roles/consul/tasks/main.yml
+++ b/roles/consul/tasks/main.yml
@@ -71,6 +71,7 @@
         # guaranteed success
         rm -rf /etc/consul.d
         rm -rf "{{ consul_data_dir }}"
+        rm -rf /etc/systemd/system/consul.service.d
         exit 0
 
 
@@ -88,6 +89,9 @@
 - name: Config consul
   tags: consul_config
   block:
+
+    - name: Add consul user to dcs group
+      user: name=consul groups=dcs append=yes
 
     - name: Create consul dir
       file: path={{ item }} state=directory owner=consul group=consul mode=0775
@@ -119,25 +123,7 @@
 
     # "disable_hostname": true is optional
     - name: Render consul main conf /etc/consul.d/consul.json
-      copy:
-        dest: /etc/consul.d/consul.json
-        mode: 0644
-        owner: consul
-        group: consul
-        content: |
-          {
-            "datacenter": "{{ dcs_name }}",
-            "node_name": "{{ nodename }}",
-            "bind_addr": "{{ inventory_hostname }}",
-            "retry_join": {{ dcs_servers.values()|list|to_json }},
-            "data_dir": "{{ consul_data_dir }}",
-            "log_level": "INFO",
-            "enable_local_script_checks": true,
-            "telemetry": {
-              "prometheus_retention_time": "15m",
-              "disable_hostname": true
-            }
-          }
+      template: src=consul.json.j2 dest=/etc/consul.d/consul.json owner=consul group=consul mode=0644
 
     - name: Render consul node meta /etc/consul.d/consul-meta.json
       copy:
@@ -197,6 +183,31 @@
     - name: Copy consul systemd service
       copy: src=consul.service dest=/usr/lib/systemd/system/consul.service
 
+    #------------------------------------------------------------------------------
+    # render consul service drop-in
+    #------------------------------------------------------------------------------
+    - name: Render consul service drop-in on /etc/systemd/system/consul.service.d/
+      when: dcs_ssl_enabled is defined and dcs_ssl_enabled|bool
+      block:
+
+        - name: Create consul.service.d directory
+          file: path=/etc/systemd/system/consul.service.d state=directory
+
+        - name: Copy consul.service drop-in
+          copy:
+            dest: /etc/systemd/system/consul.service.d/override.conf
+            owner: root
+            mode: 0644
+            content: |
+              [Service]
+              {% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+              Environment="CONSUL_HTTP_SSL=true"
+              Environment="CONSUL_HTTP_ADDR=https://127.0.0.1:8501"
+              Environment="CONSUL_CACERT={{ cert_homedir }}/{{ ca_file }}.crt"
+              {% else %}
+              Environment="CONSUL_HTTP_ADDR=http://127.0.0.1:8500"
+              {% endif %}
+
 
 #------------------------------------------------------------------------------
 # Launch consul server first
@@ -231,5 +242,25 @@
     # wait consul online
     - name: Wait for consul agent online
       wait_for: host=127.0.0.1 port=8500 state=started timeout=30
+
+
+#------------------------------------------------------------------------------
+# Write consul env & cert files to all nodes
+#------------------------------------------------------------------------------
+# write consul env & cert to all nodes
+- name: Write consul env profile
+  tags: consul_client
+  when: dcs_ssl_enabled is defined and dcs_ssl_enabled|bool
+  copy:
+    dest: /etc/profile.d/consul.sh
+    mode: 0644
+    content: |
+      {% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+      export CONSUL_HTTP_SSL=true
+      export CONSUL_HTTP_ADDR=https://127.0.0.1:8501
+      export CONSUL_CACERT={{ cert_homedir }}/{{ ca_file }}.crt
+      {% else %}
+      export CONSUL_HTTP_ADDR=http://127.0.0.1:8500
+      {% endif %}
 
 ...

--- a/roles/consul/templates/consul.json.j2
+++ b/roles/consul/templates/consul.json.j2
@@ -1,0 +1,45 @@
+{
+  "datacenter": "{{ dcs_name }}",
+  "node_name": "{{ nodename }}",
+  "bind_addr": "{{ inventory_hostname }}",
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+  "ports": {
+    "http": 8500,
+    "https": 8501
+  },
+  "tls": {
+    "defaults": {
+      "tls_min_version": "TLSv1_2",
+      "verify_outgoing": true,
+      "verify_incoming": false,
+      "ca_file": "{{ cert_homedir }}/{{ ca_file }}.crt",
+      "cert_file": "{{ cert_homedir }}/{{ pg_cluster }}-{{ pg_seq }}.crt",
+      "key_file": "{{ cert_homedir }}/{{ pg_cluster }}-{{ pg_seq }}.key"
+    },
+{% if inventory_hostname in dcs_servers.values() %}
+    "internal_rpc": {
+      "verify_incoming": true,
+      "verify_server_hostname": true
+    }
+  },
+  "auto_encrypt": {
+    "allow_tls": true
+{% else %}
+    "internal_rpc": {
+      "verify_server_hostname": true
+    }
+  },
+  "auto_encrypt": {
+    "tls": true
+{% endif %}
+  },
+{% endif %}
+  "retry_join": {{ dcs_servers.values()|list|to_json }},
+  "data_dir": "{{ consul_data_dir }}",
+  "log_level": "INFO",
+  "enable_local_script_checks": true,
+  "telemetry": {
+    "prometheus_retention_time": "15m",
+    "disable_hostname": true
+  }
+}

--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -7,6 +7,8 @@ dcs_servers: { }                  # dcs server dict in name:ip format
 dcs_registry: etcd                # where to register services: none | consul | etcd | both
 dcs_safeguard: false              # if true, running dcs will NOT be removed
 dcs_clean: false                  # if true, running dcs will be purged during node init, DANGEROUS
+dcs_gid: 980                      # gid for consul/etcd users
+dcs_ssl_enabled: false            # secure dcs communications
 
 #-----------------------------------------------------------------
 # ETCD

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -70,28 +70,30 @@
         fi
         
         # guaranteed success
-        rm -rf /etc/etcd
+        rm -rf /etc/etcd.d
         rm -rf "{{ etcd_data_dir }}"
+        rm -f /etc/profile.d/etcd.sh
         exit 0
 
 
 #------------------------------------------------------------------------------
-# Launch etcd server
+# Config etcd server
 #------------------------------------------------------------------------------
 - name: Setup etcd server
   tags: etcd_config
   when: inventory_hostname in dcs_servers.values()
   block:
 
+    - name: Add etcd user to dcs group
+      user: name=etcd groups=dcs append=yes
+
     - name: Create etcd dir
       file: path={{ item }} state=directory owner=etcd group=etcd mode=0775
       with_items:
-        - /etc/etcd
+        - /etc/etcd.d
         - "{{ etcd_data_dir }}"
 
-    #------------------------------------------------------------------------------
     # acquire dcs_nodename
-    #------------------------------------------------------------------------------
     - name: Get dcs server key as dcs nodename
       connection: local
       when: inventory_hostname in dcs_servers.values()
@@ -104,9 +106,12 @@
 
     # only server need config
     - name: Copy /etc/etcd.d/etcd.conf
-      template: src=etcd.conf.j2 dest=/etc/etcd/etcd.conf mode=0644 owner=etcd
+      template: src=etcd.conf.j2 dest=/etc/etcd.d/etcd.conf owner=etcd mode=0644
 
 
+#------------------------------------------------------------------------------
+# Launch etcd server
+#------------------------------------------------------------------------------
 - name: Launch etcd server
   tags: [ etcd_server , etcd_launch ]
   when: inventory_hostname in dcs_servers.values()
@@ -129,9 +134,13 @@
   tags: [ etcd_client, etcdctl ]
   copy:
     dest: /etc/profile.d/etcd.sh
-    mode: 0755
+    mode: 0644
     content: |
+      {% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+      export ETCDCTL_ENDPOINTS="{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}https://{{ v }}:2379{% endfor %}"
+      export ETCDCTL_CA_FILE="{{ cert_homedir }}/{{ ca_file }}.crt"
+      {% else %}
       export ETCDCTL_ENDPOINTS="{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}http://{{ v }}:2379{% endfor %}"
-      alias e="etcdctl"
+      {% endif %}
 
 ...

--- a/roles/etcd/templates/etcd.conf.j2
+++ b/roles/etcd/templates/etcd.conf.j2
@@ -1,9 +1,25 @@
 name: {{ dcs_nodename }}
 data-dir: {{ etcd_data_dir }}
+initial-cluster-token: "{{ dcs_name }}"
+initial-cluster-state: "new"
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+initial-advertise-peer-urls: https://{{ inventory_hostname }}:2380
+listen-peer-urls: https://{{ inventory_hostname }}:2380
+listen-client-urls: "https://{{ inventory_hostname }}:2379,https://127.0.0.1:2379"
+advertise-client-urls: https://{{ inventory_hostname }}:2379
+initial-cluster: "{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}{{ k }}=https://{{ v }}:2380{% endfor %}"
+client-transport-security:
+  cert-file: "{{ cert_homedir }}/{{ pg_cluster }}-{{ pg_seq }}.crt"
+  key-file: "{{ cert_homedir }}/{{ pg_cluster }}-{{ pg_seq }}.key"
+  trusted-ca-file: "{{ cert_homedir }}/{{ ca_file }}.crt"
+peer-transport-security:
+  cert-file: "{{ cert_homedir }}/{{ pg_cluster }}-{{ pg_seq }}.crt"
+  key-file: "{{ cert_homedir }}/{{ pg_cluster }}-{{ pg_seq }}.key"
+  trusted-ca-file: "{{ cert_homedir }}/{{ ca_file }}.crt"
+{% else %}
 initial-advertise-peer-urls: http://{{ inventory_hostname }}:2380
 listen-peer-urls: http://{{ inventory_hostname }}:2380
 listen-client-urls: "http://{{ inventory_hostname }}:2379,http://127.0.0.1:2379"
 advertise-client-urls: http://{{ inventory_hostname }}:2379
 initial-cluster: "{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}{{ k }}=http://{{ v }}:2380{% endfor %}"
-initial-cluster-token: "{{ dcs_name }}"
-initial-cluster-state: "new"
+{% endif %}

--- a/roles/etcd/templates/etcd.service.j2
+++ b/roles/etcd/templates/etcd.service.j2
@@ -8,7 +8,7 @@ Wants=network-online.target
 Type=notify
 #WorkingDirectory={{ etcd_data_dir }}
 User=etcd
-ExecStart=/usr/bin/etcd --config-file /etc/etcd/etcd.conf
+ExecStart=/usr/bin/etcd --config-file /etc/etcd.d/etcd.conf
 Restart=on-failure
 LimitNOFILE=65536
 

--- a/roles/grafana/tasks/config.yml
+++ b/roles/grafana/tasks/config.yml
@@ -30,7 +30,7 @@
   template: src=grafana.ini dest=/etc/grafana/grafana.ini owner=grafana group=grafana
 
 - name: Templating datasources provisioning config
-  template: src=datasources-pigsty.yml dest=/etc/grafana/provisioning/datasources/pigsty.yml owner=grafana group=grafana
+  template: src=datasources-pigsty.yml.j2 dest=/etc/grafana/provisioning/datasources/pigsty.yml owner=grafana group=grafana
 
 - name: Templating dashboards provisioning config
   template: src=dashboards-pigsty.yml dest=/etc/grafana/provisioning/dashboards/pigsty.yml owner=grafana group=grafana

--- a/roles/grafana/templates/datasources-pigsty.yml.j2
+++ b/roles/grafana/templates/datasources-pigsty.yml.j2
@@ -41,8 +41,8 @@ datasources:
       "connMaxLifetime": 14400,
       "maxIdleConns": 10,
       "maxOpenConns": 64,
-      "postgresVersion": 1300,
-      "sslmode": "disable",
+      "postgresVersion": {{ pg_version }}00,
+      "sslmode": "{{ pg_sslmode }}",
       "tlsAuth": false,
       "tlsAuthWithCACert": false
     }

--- a/roles/grafana/templates/grafana.ini
+++ b/roles/grafana/templates/grafana.ini
@@ -94,7 +94,11 @@ provisioning = /etc/grafana/provisioning
 {% if grafana_database == 'postgres' %}
 # use postgres as primary database
 url = {{ grafana_pgurl }}
+{% if pg_sslmode != 'disable' %}
+ssl_mode = require
+{% else %}
 ssl_mode = disable
+{% endif %}
 {% endif %}
 
 # For "postgres" only, either "disable", "require" or "verify-full"

--- a/roles/node/files/profile.sh
+++ b/roles/node/files/profile.sh
@@ -94,11 +94,12 @@ function pg() {
 
 alias ntpsync="sudo ntpdate pool.ntp.org"
 
-# consul alias
+# dcs alias
 alias cnode="consul catalog nodes -detailed"
 alias csvc="consul catalog services --tags"
 alias cst="systemctl status consul"
 alias cm="consul members"
+alias e="etcdctl"
 #--------------------------------------------------------------#
 # ls corlor
 [ ls --color ] >/dev/null 2>&1 && colorflag="--color" || colorflag="-G"

--- a/roles/node/tasks/admin.yml
+++ b/roles/node/tasks/admin.yml
@@ -4,7 +4,7 @@
 #==============================================================#
 - name: Copy default user bash profile
   tags: node_profile
-  copy: src=profile.sh dest=/etc/profile.d/profile.sh mode=755
+  copy: src=profile.sh dest=/etc/profile.d/profile.sh mode=0644
 
 #==============================================================#
 # Stage 2: Setup pam ulimit for node users
@@ -22,7 +22,14 @@
     [[ -d {{ node_data_dir }} ]] || mkdir -p {{ node_data_dir }} -m 777
 
 #==============================================================#
-# Stage 4: Create default users/groups
+# Stage 4: Create dcs group
+#==============================================================#
+- name: Create dcs group
+  tags: node_group
+  group: name=dcs gid={{ dcs_gid }}
+
+#==============================================================#
+# Stage 5: Create default users/groups
 #==============================================================#
 - name: Create node users and groups
   tags: node_admin
@@ -35,6 +42,7 @@
     # create user and group
     - name: Create os user group admin
       group: name=admin gid={{ node_admin_uid }}
+
     - name: Create os user admin
       user: name={{ node_admin_username }} uid={{ node_admin_uid }} home=/home/{{ node_admin_username }} group=admin generate_ssh_key=yes
 

--- a/roles/pg_exporter/templates/pgbouncer_exporter.j2
+++ b/roles/pg_exporter/templates/pgbouncer_exporter.j2
@@ -1,7 +1,7 @@
 {% if pgbouncer_exporter_url != '' %}
 PG_EXPORTER_URL='{{ pgbouncer_exporter_url }}
 {% else %}
-PG_EXPORTER_URL='postgres://{{ pg_monitor_username }}:{{ pg_monitor_password }}@:{{ pgbouncer_port }}/pgbouncer?host={{ pg_localhost }}&sslmode=disable'
+PG_EXPORTER_URL='postgres://{{ pg_monitor_username }}:{{ pg_monitor_password }}@:{{ pgbouncer_port }}/pgbouncer?host={{ pg_localhost }}&sslmode={{ pg_sslmode }}'
 {% endif %}
 PG_EXPORTER_CONFIG=/etc/pg_exporter.yml
 PG_EXPORTER_LISTEN_ADDRESS=":{{ pgbouncer_exporter_port }}"

--- a/roles/pg_register/tasks/grafana.yml
+++ b/roles/pg_register/tasks/grafana.yml
@@ -32,7 +32,7 @@
               "maxIdleConns": 1,
               "maxOpenConns": 8,
               "postgresVersion": {{ pg_version }}00,
-              "sslmode": "disable",
+              "sslmode": "{{ pg_sslmode }}",
               "tlsAuth": false,
               "tlsAuthWithCACert": false
             },

--- a/roles/pg_remove/tasks/postgres.yml
+++ b/roles/pg_remove/tasks/postgres.yml
@@ -110,15 +110,33 @@
       become_user: "{{ pg_dbsu }}"
       shell: "{{ pg_bin_dir }}/pg_ctl -D {{ pg_data }} stop -m immediate; /bin/true"
 
-    # when cleanup primary, remove pgsql cluster meta data
-    - name: Remove consul metadata about pgsql cluster
-      when: pg_dcs_type == 'consul'
-      shell: |
-        consul kv delete -recurse {{ pg_namespace }}/{{ pg_cluster }} ; /bin/true
+    # when cleanup primary, remove dcs metadata
+    - name: Remove dcs postgres metadata
+      ignore_errors: true
+      when: pg_role == 'primary'
+      block:
 
-    - name: Remove etcd metadata about pgsql cluster
-      when: pg_dcs_type == 'etcd'
-      shell: |
-        ETCDCTL_ENDPOINTS="{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}{{ v }}:2379{% endfor %}"
-        etcdctl rm -r {{ pg_namespace }}/{{ pg_cluster }} ; /bin/true
+        - name: Remove postgres metadata in consul
+          when: pg_dcs_type == 'consul'
+          shell: |
+            {% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+            export CONSUL_HTTP_SSL=true
+            export CONSUL_HTTP_ADDR=https://127.0.0.1:8501
+            export CONSUL_CACERT={{ cert_homedir }}/{{ ca_file }}.crt
+            {% else %}
+            export CONSUL_HTTP_ADDR=http://127.0.0.1:8500
+            {% endif %}
+            consul kv delete -recurse {{ pg_namespace }}/{{ pg_cluster }}; /bin/true
+
+        - name: Remove postgres metadata in etcd
+          when: pg_dcs_type == 'etcd'
+          shell: |
+            {% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+            export ETCDCTL_ENDPOINTS="{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}https://{{ v }}:2379{% endfor %}"
+            export ETCDCTL_CA_FILE="{{ cert_homedir }}/{{ ca_file }}.crt"
+            {% else %}
+            export ETCDCTL_ENDPOINTS="{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}http://{{ v }}:2379{% endfor %}"
+            {% endif %}
+            etcdctl rm -r {{ pg_namespace }}/{{ pg_cluster }}; /bin/true
+
 ...

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -82,11 +82,14 @@ patroni_mode: default             # pause|default|remove
 pg_dcs_type: consul               # consul or etcd or raft
 pg_namespace: /pg                 # top level key namespace in dcs
 patroni_port: 8008                # default patroni port
+patroni_log_dir: /pg/log          # patroni log dir, default is /pg/log
+patroni_ssl_enabled: false        # secure patroni communications
 patroni_watchdog_mode: automatic  # watchdog mode: off|automatic|required
 pg_conf: tiny.yml                 # pgsql template:  {oltp|olap|crit|tiny}.yml
 pg_libs: 'pg_stat_statements, auto_explain'  # extensions to be loaded
 pg_delay: 0                       # apply delay for standby cluster leader
 pg_checksum: false                # enable data checksum by default
+pg_sslmode: disable               # enable sslmode: disable|allow|prefer|require|verify-ca|verify-full
 pg_encoding: UTF8                 # database cluster encoding, UTF8 by default
 pg_locale: C                      # database cluster local, C by default
 pg_lc_collate: C                  # database cluster collate, C by default

--- a/roles/postgres/tasks/install.yml
+++ b/roles/postgres/tasks/install.yml
@@ -11,11 +11,10 @@
       group: name=postgres gid={{ pg_dbsu_uid }}
 
     - name: Make sure dcs group exists
-      group: name={{ item }}
-      with_items: [consul, etcd]
+      group: name=dcs
 
     - name: Create dbsu {{ pg_dbsu }}
-      user: name={{ pg_dbsu }} uid={{ pg_dbsu_uid }} home={{ pg_dbsu_home }} group=postgres groups=consul,etcd generate_ssh_key=yes
+      user: name={{ pg_dbsu }} uid={{ pg_dbsu_uid }} home={{ pg_dbsu_home }} group=postgres groups=dcs generate_ssh_key=yes
 
     # - dbsu privilege - #
     - name: Grant dbsu nopass sudo

--- a/roles/postgres/tasks/patroni.yml
+++ b/roles/postgres/tasks/patroni.yml
@@ -136,7 +136,7 @@
       wait_for: host={{ inventory_hostname }} port={{ patroni_port }} state=started timeout=60
 
     - name: Wait for postgres primary online
-      wait_for: host={{ inventory_hostname }} port={{ pg_port }} state=started timeout=10
+      wait_for: host={{ inventory_hostname }} port={{ pg_port }} state=started timeout=60
 
     - name: Check primary postgres service ready
       become_user: "{{ pg_dbsu }}"

--- a/roles/postgres/tasks/prepare.yml
+++ b/roles/postgres/tasks/prepare.yml
@@ -74,26 +74,42 @@
         fi
         exit 0
 
-    - name: Remove registerd consul service
-      ignore_errors: yes
-      shell: |
-        rm -rf /etc/consul.d/svc-*.json
-        /usr/bin/consul reload
-        exit 0
+    # this will cleanup services registered in infra_register playbook
+    # - name: Remove registerd consul service
+    #   ignore_errors: yes
+    #   shell: |
+    #     rm -rf /etc/consul.d/svc-*.json
+    #     systemctl reload consul
+    #     exit 0
 
-    # when cleanup primary, remove consul metadata in consul
-    - name: Remove postgres metadata in consul
+    # when cleanup primary, remove dcs metadata
+    - name: Remove dcs postgres metadata
       ignore_errors: true
-      when: pg_role == 'primary' and pg_dcs_type == 'consul'
-      shell: |
-        consul kv delete -recurse {{ pg_namespace }}/{{ pg_cluster }}
+      when: pg_role == 'primary'
+      block:
 
-    - name: Remove postgres metadata in etcd
-      ignore_errors: true
-      when: pg_role == 'primary' and pg_dcs_type == 'etcd'
-      shell: |
-        ETCDCTL_ENDPOINTS="{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}{{ v }}:2379{% endfor %}"
-        etcdctl rm -r {{ pg_namespace }}/{{ pg_cluster }}
+        - name: Remove postgres metadata in consul
+          when: pg_dcs_type == 'consul'
+          shell: |
+            {% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+            export CONSUL_HTTP_SSL=true
+            export CONSUL_HTTP_ADDR=https://127.0.0.1:8501
+            export CONSUL_CACERT={{ cert_homedir }}/{{ ca_file }}.crt      
+            {% else %}
+            export CONSUL_HTTP_ADDR=http://127.0.0.1:8500
+            {% endif %}   
+            consul kv delete -recurse {{ pg_namespace }}/{{ pg_cluster }}; /bin/true
+
+        - name: Remove postgres metadata in etcd
+          when: pg_dcs_type == 'etcd'
+          shell: |
+            {% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+            export ETCDCTL_ENDPOINTS="{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}https://{{ v }}:2379{% endfor %}"
+            export ETCDCTL_CA_FILE="{{ cert_homedir }}/{{ ca_file }}.crt"
+            {% else %}
+            export ETCDCTL_ENDPOINTS="{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}http://{{ v }}:2379{% endfor %}"
+            {% endif %}
+            etcdctl rm -r {{ pg_namespace }}/{{ pg_cluster }}; /bin/true
 
     # TODO: only remove necessary dir instead of all
     - name: Remove existing postgres data

--- a/roles/postgres/templates/crit.yml
+++ b/roles/postgres/templates/crit.yml
@@ -39,18 +39,27 @@ log:
 #------------------------------------------------------------------------------
 {% if pg_dcs_type == 'consul' %}
 consul:
-  host: 127.0.0.1:8500
   consistency: default         # default|consistent|stale
   register_service: true
   service_check_interval: 15s
   service_tags:
     - {{ pg_cluster }}
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+  host: 127.0.0.1:8501
+  scheme: https
+  cacert: {{ cert_homedir }}/{{ ca_file }}.crt
+{% else %}
+  host: 127.0.0.1:8500
+{% endif %}
 {% endif %}
 {% if pg_dcs_type == 'etcd' %}
 etcd:
   hosts: '{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}{{ v }}:2379{% endfor %}'
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+  protocol: https
+  cacert: {{ cert_homedir }}/{{ ca_file }}.crt
 {% endif %}
-
+{% endif %}
 
 #------------------------------------------------------------------------------
 # api
@@ -65,16 +74,19 @@ restapi:
     username: {{ pg_monitor_username }}
     password: '{{ pg_monitor_password }}'
 
-
 #------------------------------------------------------------------------------
 # ctl
 #------------------------------------------------------------------------------
 ctl:
   optional:
+{% if patroni_ssl_enabled is defined and patroni_ssl_enabled|bool %}
+    insecure: false
+    cacert: '{{ cert_homedir }}/{{ ca_file }}.crt'
+    certfile: '{{ cert_homedir }}/{{ pg_instance }}.crt'
+    keyfile: '{{ cert_homedir }}/{{ pg_instance }}.key'
+{% else %}
     insecure: true
-    # cacert: '/path/to/ca/cert'
-    # certfile: '/path/to/cert/file'
-    # keyfile: '/path/to/key/file'
+{% endif %}
 
 #------------------------------------------------------------------------------
 # tags
@@ -235,6 +247,12 @@ bootstrap:
         max_replication_slots: 16               # 10 -> 16
         wal_keep_size: 100GB                    # keep at least 100GB WAL
         password_encryption: md5                # use traditional md5 auth
+{% if pg_sslmode != 'disable' %}
+        ssl: on
+        ssl_cert_file: '{{ cert_homedir }}/{{ pg_cluster }}.crt'
+        ssl_key_file: '{{ cert_homedir }}/{{ pg_cluster }}.key'
+        ssl_ca_file: '{{ cert_homedir }}/{{ ca_file }}.crt'
+{% endif %}
 
         #----------------------------------------------------------------------
         # RESOURCE USAGE (except WAL)

--- a/roles/postgres/templates/datasource.json.j2
+++ b/roles/postgres/templates/datasource.json.j2
@@ -4,7 +4,6 @@
   "name": "{{ pg_instance }}",
   "url": "{{ inventory_hostname }}:{{ pg_port }}",
   "user": "{{ pg_monitor_username }}",
-  "password": "{{ pg_monitor_password }}",
   "database": "{{ pg_default_database }}",
   "typeLogoUrl": "",
   "basicAuth": false,
@@ -16,9 +15,12 @@
     "connMaxLifetime": 3600,
     "maxIdleConns": 1,
     "maxOpenConns": 8,
-    "postgresVersion": 1300,
-    "sslmode": "disable",
+    "postgresVersion": {{ pg_version }}00,
+    "sslmode": "{{ pg_sslmode }}",
     "tlsAuth": false,
     "tlsAuthWithCACert": false
+  },
+  "secureJsonData":{
+    "password": "{{ pg_monitor_password }}"
   }
 }

--- a/roles/postgres/templates/large.yml
+++ b/roles/postgres/templates/large.yml
@@ -39,16 +39,26 @@ log:
 #------------------------------------------------------------------------------
 {% if pg_dcs_type == 'consul' %}
 consul:
-  host: 127.0.0.1:8500
   consistency: default         # default|consistent|stale
   register_service: true
   service_check_interval: 15s
   service_tags:
     - {{ pg_cluster }}
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+  host: 127.0.0.1:8501
+  scheme: https
+  cacert: {{ cert_homedir }}/{{ ca_file }}.crt
+{% else %}
+  host: 127.0.0.1:8500
+{% endif %}
 {% endif %}
 {% if pg_dcs_type == 'etcd' %}
 etcd:
   hosts: '{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}{{ v }}:2379{% endfor %}'
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+  protocol: https
+  cacert: {{ cert_homedir }}/{{ ca_file }}.crt
+{% endif %}
 {% endif %}
 
 #------------------------------------------------------------------------------
@@ -64,16 +74,19 @@ restapi:
     username: {{ pg_monitor_username }}
     password: '{{ pg_monitor_password }}'
 
-
 #------------------------------------------------------------------------------
 # ctl
 #------------------------------------------------------------------------------
 ctl:
   optional:
+{% if patroni_ssl_enabled is defined and patroni_ssl_enabled|bool %}
+    insecure: false
+    cacert: '{{ cert_homedir }}/{{ ca_file }}.crt'
+    certfile: '{{ cert_homedir }}/{{ pg_instance }}.crt'
+    keyfile: '{{ cert_homedir }}/{{ pg_instance }}.key'
+{% else %}
     insecure: true
-    # cacert: '/path/to/ca/cert'
-    # certfile: '/path/to/cert/file'
-    # keyfile: '/path/to/key/file'
+{% endif %}
 
 #------------------------------------------------------------------------------
 # tags
@@ -234,6 +247,12 @@ bootstrap:
         max_replication_slots: 16               # 10 -> 16
         wal_keep_size: 100GB                    # keep at least 100GB WAL
         password_encryption: md5                # use traditional md5 auth
+{% if pg_sslmode != 'disable' %}
+        ssl: on
+        ssl_cert_file: '{{ cert_homedir }}/{{ pg_cluster }}.crt'
+        ssl_key_file: '{{ cert_homedir }}/{{ pg_cluster }}.key'
+        ssl_ca_file: '{{ cert_homedir }}/{{ ca_file }}.crt'
+{% endif %}
 
         #----------------------------------------------------------------------
         # RESOURCE USAGE (except WAL)

--- a/roles/postgres/templates/medium.yml
+++ b/roles/postgres/templates/medium.yml
@@ -37,18 +37,27 @@ log:
 #------------------------------------------------------------------------------
 {% if pg_dcs_type == 'consul' %}
 consul:
-  host: 127.0.0.1:8500
   consistency: default         # default|consistent|stale
   register_service: true
   service_check_interval: 15s
   service_tags:
     - {{ pg_cluster }}
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+  host: 127.0.0.1:8501
+  scheme: https
+  cacert: {{ cert_homedir }}/{{ ca_file }}.crt
+{% else %}
+  host: 127.0.0.1:8500
+{% endif %}
 {% endif %}
 {% if pg_dcs_type == 'etcd' %}
 etcd:
   hosts: '{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}{{ v }}:2379{% endfor %}'
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+  protocol: https
+  cacert: {{ cert_homedir }}/{{ ca_file }}.crt
 {% endif %}
-
+{% endif %}
 
 #------------------------------------------------------------------------------
 # api
@@ -63,16 +72,19 @@ restapi:
     username: {{ pg_monitor_username }}
     password: '{{ pg_monitor_password }}'
 
-
 #------------------------------------------------------------------------------
 # ctl
 #------------------------------------------------------------------------------
 ctl:
   optional:
+{% if patroni_ssl_enabled is defined and patroni_ssl_enabled|bool %}
+    insecure: false
+    cacert: '{{ cert_homedir }}/{{ ca_file }}.crt'
+    certfile: '{{ cert_homedir }}/{{ pg_instance }}.crt'
+    keyfile: '{{ cert_homedir }}/{{ pg_instance }}.key'
+{% else %}
     insecure: true
-    # cacert: '/path/to/ca/cert'
-    # certfile: '/path/to/cert/file'
-    # keyfile: '/path/to/key/file'
+{% endif %}
 
 #------------------------------------------------------------------------------
 # tags
@@ -233,6 +245,12 @@ bootstrap:
         max_replication_slots: 16               # 10 -> 16
         wal_keep_size: 20GB                     # keep at least 20GB WAL
         password_encryption: md5                # use traditional md5 auth
+{% if pg_sslmode != 'disable' %}
+        ssl: on
+        ssl_cert_file: '{{ cert_homedir }}/{{ pg_cluster }}.crt'
+        ssl_key_file: '{{ cert_homedir }}/{{ pg_cluster }}.key'
+        ssl_ca_file: '{{ cert_homedir }}/{{ ca_file }}.crt'
+{% endif %}
 
         #----------------------------------------------------------------------
         # RESOURCE USAGE (except WAL)

--- a/roles/postgres/templates/mini.yml
+++ b/roles/postgres/templates/mini.yml
@@ -37,18 +37,27 @@ log:
 #------------------------------------------------------------------------------
 {% if pg_dcs_type == 'consul' %}
 consul:
-  host: 127.0.0.1:8500
   consistency: default         # default|consistent|stale
   register_service: true
   service_check_interval: 15s
   service_tags:
     - {{ pg_cluster }}
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+  host: 127.0.0.1:8501
+  scheme: https
+  cacert: {{ cert_homedir }}/{{ ca_file }}.crt
+{% else %}
+  host: 127.0.0.1:8500
+{% endif %}
 {% endif %}
 {% if pg_dcs_type == 'etcd' %}
 etcd:
   hosts: '{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}{{ v }}:2379{% endfor %}'
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+  protocol: https
+  cacert: {{ cert_homedir }}/{{ ca_file }}.crt
 {% endif %}
-
+{% endif %}
 
 #------------------------------------------------------------------------------
 # api
@@ -63,16 +72,19 @@ restapi:
     username: {{ pg_monitor_username }}
     password: '{{ pg_monitor_password }}'
 
-
 #------------------------------------------------------------------------------
 # ctl
 #------------------------------------------------------------------------------
 ctl:
   optional:
+{% if patroni_ssl_enabled is defined and patroni_ssl_enabled|bool %}
+    insecure: false
+    cacert: '{{ cert_homedir }}/{{ ca_file }}.crt'
+    certfile: '{{ cert_homedir }}/{{ pg_instance }}.crt'
+    keyfile: '{{ cert_homedir }}/{{ pg_instance }}.key'
+{% else %}
     insecure: true
-    # cacert: '/path/to/ca/cert'
-    # certfile: '/path/to/cert/file'
-    # keyfile: '/path/to/key/file'
+{% endif %}
 
 #------------------------------------------------------------------------------
 # tags
@@ -233,6 +245,12 @@ bootstrap:
         # max_replication_slots: 16             # 10 -> 16
         wal_keep_size: 1GB                      # keep at least 1GB WAL
         password_encryption: md5                # use traditional md5 auth
+{% if pg_sslmode != 'disable' %}
+        ssl: on
+        ssl_cert_file: '{{ cert_homedir }}/{{ pg_cluster }}.crt'
+        ssl_key_file: '{{ cert_homedir }}/{{ pg_cluster }}.key'
+        ssl_ca_file: '{{ cert_homedir }}/{{ ca_file }}.crt'
+{% endif %}
 
         #----------------------------------------------------------------------
         # RESOURCE USAGE (except WAL)

--- a/roles/postgres/templates/olap.yml
+++ b/roles/postgres/templates/olap.yml
@@ -39,18 +39,27 @@ log:
 #------------------------------------------------------------------------------
 {% if pg_dcs_type == 'consul' %}
 consul:
-  host: 127.0.0.1:8500
   consistency: default         # default|consistent|stale
   register_service: true
   service_check_interval: 15s
   service_tags:
     - {{ pg_cluster }}
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+  host: 127.0.0.1:8501
+  scheme: https
+  cacert: {{ cert_homedir }}/{{ ca_file }}.crt
+{% else %}
+  host: 127.0.0.1:8500
+{% endif %}
 {% endif %}
 {% if pg_dcs_type == 'etcd' %}
 etcd:
   hosts: '{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}{{ v }}:2379{% endfor %}'
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+  protocol: https
+  cacert: {{ cert_homedir }}/{{ ca_file }}.crt
 {% endif %}
-
+{% endif %}
 
 #------------------------------------------------------------------------------
 # api
@@ -71,10 +80,14 @@ restapi:
 #------------------------------------------------------------------------------
 ctl:
   optional:
+{% if patroni_ssl_enabled is defined and patroni_ssl_enabled|bool %}
+    insecure: false
+    cacert: '{{ cert_homedir }}/{{ ca_file }}.crt'
+    certfile: '{{ cert_homedir }}/{{ pg_instance }}.crt'
+    keyfile: '{{ cert_homedir }}/{{ pg_instance }}.key'
+{% else %}
     insecure: true
-    # cacert: '/path/to/ca/cert'
-    # certfile: '/path/to/cert/file'
-    # keyfile: '/path/to/key/file'
+{% endif %}
 
 #------------------------------------------------------------------------------
 # tags
@@ -235,6 +248,12 @@ bootstrap:
         max_replication_slots: 16               # 10 -> 16
         wal_keep_size: 100GB                    # keep at least 100GB WAL
         password_encryption: md5                # use traditional md5 auth
+{% if pg_sslmode != 'disable' %}
+        ssl: on
+        ssl_cert_file: '{{ cert_homedir }}/{{ pg_cluster }}.crt'
+        ssl_key_file: '{{ cert_homedir }}/{{ pg_cluster }}.key'
+        ssl_ca_file: '{{ cert_homedir }}/{{ ca_file }}.crt'
+{% endif %}
 
         #----------------------------------------------------------------------
         # RESOURCE USAGE (except WAL)

--- a/roles/postgres/templates/oltp.yml
+++ b/roles/postgres/templates/oltp.yml
@@ -39,18 +39,27 @@ log:
 #------------------------------------------------------------------------------
 {% if pg_dcs_type == 'consul' %}
 consul:
-  host: 127.0.0.1:8500
   consistency: default         # default|consistent|stale
   register_service: true
   service_check_interval: 15s
   service_tags:
     - {{ pg_cluster }}
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+  host: 127.0.0.1:8501
+  scheme: https
+  cacert: {{ cert_homedir }}/{{ ca_file }}.crt
+{% else %}
+  host: 127.0.0.1:8500
+{% endif %}
 {% endif %}
 {% if pg_dcs_type == 'etcd' %}
 etcd:
   hosts: '{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}{{ v }}:2379{% endfor %}'
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+  protocol: https
+  cacert: {{ cert_homedir }}/{{ ca_file }}.crt
 {% endif %}
-
+{% endif %}
 
 #------------------------------------------------------------------------------
 # api
@@ -65,16 +74,19 @@ restapi:
     username: {{ pg_monitor_username }}
     password: '{{ pg_monitor_password }}'
 
-
 #------------------------------------------------------------------------------
 # ctl
 #------------------------------------------------------------------------------
 ctl:
   optional:
+{% if patroni_ssl_enabled is defined and patroni_ssl_enabled|bool %}
+    insecure: false
+    cacert: '{{ cert_homedir }}/{{ ca_file }}.crt'
+    certfile: '{{ cert_homedir }}/{{ pg_instance }}.crt'
+    keyfile: '{{ cert_homedir }}/{{ pg_instance }}.key'
+{% else %}
     insecure: true
-    # cacert: '/path/to/ca/cert'
-    # certfile: '/path/to/cert/file'
-    # keyfile: '/path/to/key/file'
+{% endif %}
 
 #------------------------------------------------------------------------------
 # tags
@@ -235,6 +247,12 @@ bootstrap:
         max_replication_slots: 16               # 10 -> 16
         wal_keep_size: 100GB                    # keep at least 100GB WAL
         password_encryption: md5                # use traditional md5 auth
+{% if pg_sslmode != 'disable' %}
+        ssl: on
+        ssl_cert_file: '{{ cert_homedir }}/{{ pg_cluster }}.crt'
+        ssl_key_file: '{{ cert_homedir }}/{{ pg_cluster }}.key'
+        ssl_ca_file: '{{ cert_homedir }}/{{ ca_file }}.crt'
+{% endif %}
 
         #----------------------------------------------------------------------
         # RESOURCE USAGE (except WAL)

--- a/roles/postgres/templates/pg_hba.conf.j2
+++ b/roles/postgres/templates/pg_hba.conf.j2
@@ -10,17 +10,31 @@ local   all             all                                    md5
 
 # allow local/intranet replication with password
 local   replication     {{ pg_replication_username }}                              md5
+{% if pg_sslmode != 'disable' %}
+hostssl replication     {{ pg_replication_username }}         127.0.0.1/32         md5
+hostssl all             {{ pg_replication_username }}         10.0.0.0/8           md5
+hostssl all             {{ pg_replication_username }}         172.16.0.0/12        md5
+hostssl all             {{ pg_replication_username }}         192.168.0.0/16       md5
+hostssl replication     {{ pg_replication_username }}         10.0.0.0/8           md5
+hostssl replication     {{ pg_replication_username }}         172.16.0.0/12        md5
+hostssl replication     {{ pg_replication_username }}         192.168.0.0/16       md5
+{% else %}
 host    replication     {{ pg_replication_username }}         127.0.0.1/32         md5
-host    all             {{ pg_replication_username }}         10.0.0.0/8           md5
-host    all             {{ pg_replication_username }}         172.16.0.0/12        md5
-host    all             {{ pg_replication_username }}         192.168.0.0/16       md5
+host    postgres        {{ pg_replication_username }}         10.0.0.0/8           md5
+host    postgres        {{ pg_replication_username }}         172.16.0.0/12        md5
+host    postgres        {{ pg_replication_username }}         192.168.0.0/16       md5
 host    replication     {{ pg_replication_username }}         10.0.0.0/8           md5
 host    replication     {{ pg_replication_username }}         172.16.0.0/12        md5
 host    replication     {{ pg_replication_username }}         192.168.0.0/16       md5
+{% endif %}
 
 # allow local role monitor with password
 local   all             {{ pg_monitor_username }}                          md5
+{% if pg_sslmode != 'disable' %}
+hostssl all             {{ pg_monitor_username }}      127.0.0.1/32        md5
+{% else %}
 host    all             {{ pg_monitor_username }}      127.0.0.1/32        md5
+{% endif %}
 
 #==============================================================#
 # Extra HBA

--- a/roles/postgres/templates/pgb_hba.conf.j2
+++ b/roles/postgres/templates/pgb_hba.conf.j2
@@ -2,19 +2,39 @@
 # Default HBA
 #==============================================================#
 # local dbsu quick access
-local  pgbouncer postgres                                       peer
+local     pgbouncer    postgres                                    peer
 
 # local all password access (for biz user test)
-local   all     all                                             md5
-host    all     all                         127.0.0.1/32        md5
+local     all          all                                         scram-sha-256
+{% if pg_sslmode != 'disable' %}
+hostssl   all          all                         127.0.0.1/32    scram-sha-256
 
 # monitor user intranet access to pgbouncer stats
-host   pgbouncer    {{ pg_monitor_username }}   10.0.0.0/8      md5
-host   all          {{ pg_monitor_username }}   0.0.0.0/0       reject
+hostssl   pgbouncer    {{ pg_monitor_username }}   10.0.0.0/8      scram-sha-256
+hostssl   pgbouncer    {{ pg_monitor_username }}   172.16.0.0/12   scram-sha-256
+hostssl   pgbouncer    {{ pg_monitor_username }}   192.168.0.0/16  scram-sha-256
+hostssl   all          {{ pg_monitor_username }}   0.0.0.0/0       reject
 
 # admin user have intranet access to pgbouncer admin
-host   pgbouncer    {{ pg_admin_username }}     10.0.0.0/8      md5
-host   all          {{ pg_admin_username }}     0.0.0.0/0       reject
+hostssl   pgbouncer    {{ pg_admin_username }}     10.0.0.0/8      scram-sha-256
+hostssl   pgbouncer    {{ pg_admin_username }}     172.16.0.0/12   scram-sha-256
+hostssl   pgbouncer    {{ pg_admin_username }}     192.168.0.0/16  scram-sha-256
+hostssl   all          {{ pg_admin_username }}     0.0.0.0/0       reject
+{% else %}
+host      all          all                         127.0.0.1/32    scram-sha-256
+
+# monitor user intranet access to pgbouncer stats
+host      pgbouncer    {{ pg_monitor_username }}   10.0.0.0/8      scram-sha-256
+host      pgbouncer    {{ pg_monitor_username }}   172.16.0.0/12   scram-sha-256
+host      pgbouncer    {{ pg_monitor_username }}   192.168.0.0/16  scram-sha-256
+host      all          {{ pg_monitor_username }}   0.0.0.0/0       reject
+
+# admin user have intranet access to pgbouncer admin
+host      pgbouncer    {{ pg_admin_username }}     10.0.0.0/8      scram-sha-256
+host      pgbouncer    {{ pg_admin_username }}     172.16.0.0/12   scram-sha-256
+host      pgbouncer    {{ pg_admin_username }}     192.168.0.0/16  scram-sha-256
+host      all          {{ pg_admin_username }}     0.0.0.0/0       reject
+{% endif %}
 
 #==============================================================#
 # Common HBA

--- a/roles/postgres/templates/pgbouncer.ini.j2
+++ b/roles/postgres/templates/pgbouncer.ini.j2
@@ -27,3 +27,9 @@ max_db_connections          = {{ pgbouncer_max_db_conn }}
 log_connections             = 0
 log_disconnections          = 0
 ignore_startup_parameters   = extra_float_digits
+{% if pg_sslmode != 'disable' %}
+client_tls_sslmode          = {{ pg_sslmode }}
+client_tls_cert_file        = {{ cert_homedir }}/{{ pg_instance }}.crt
+client_tls_key_file         = {{ cert_homedir }}/{{ pg_instance }}.key
+client_tls_ca_file          = {{ cert_homedir }}/{{ ca_file }}.crt
+{% endif %}

--- a/roles/postgres/templates/small.yml
+++ b/roles/postgres/templates/small.yml
@@ -37,18 +37,27 @@ log:
 #------------------------------------------------------------------------------
 {% if pg_dcs_type == 'consul' %}
 consul:
-  host: 127.0.0.1:8500
   consistency: default         # default|consistent|stale
   register_service: true
   service_check_interval: 15s
   service_tags:
     - {{ pg_cluster }}
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+  host: 127.0.0.1:8501
+  scheme: https
+  cacert: {{ cert_homedir }}/{{ ca_file }}.crt
+{% else %}
+  host: 127.0.0.1:8500
+{% endif %}
 {% endif %}
 {% if pg_dcs_type == 'etcd' %}
 etcd:
   hosts: '{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}{{ v }}:2379{% endfor %}'
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+  protocol: https
+  cacert: {{ cert_homedir }}/{{ ca_file }}.crt
 {% endif %}
-
+{% endif %}
 
 #------------------------------------------------------------------------------
 # api
@@ -63,16 +72,19 @@ restapi:
     username: {{ pg_monitor_username }}
     password: '{{ pg_monitor_password }}'
 
-
 #------------------------------------------------------------------------------
 # ctl
 #------------------------------------------------------------------------------
 ctl:
   optional:
+{% if patroni_ssl_enabled is defined and patroni_ssl_enabled|bool %}
+    insecure: false
+    cacert: '{{ cert_homedir }}/{{ ca_file }}.crt'
+    certfile: '{{ cert_homedir }}/{{ pg_instance }}.crt'
+    keyfile: '{{ cert_homedir }}/{{ pg_instance }}.key'
+{% else %}
     insecure: true
-    # cacert: '/path/to/ca/cert'
-    # certfile: '/path/to/cert/file'
-    # keyfile: '/path/to/key/file'
+{% endif %}
 
 #------------------------------------------------------------------------------
 # tags
@@ -233,6 +245,12 @@ bootstrap:
         max_replication_slots: 16               # 10 -> 16
         wal_keep_size: 10GB                     # keep at least 20GB WAL
         password_encryption: md5                # use traditional md5 auth
+{% if pg_sslmode != 'disable' %}
+        ssl: on
+        ssl_cert_file: '{{ cert_homedir }}/{{ pg_cluster }}.crt'
+        ssl_key_file: '{{ cert_homedir }}/{{ pg_cluster }}.key'
+        ssl_ca_file: '{{ cert_homedir }}/{{ ca_file }}.crt'
+{% endif %}
 
         #----------------------------------------------------------------------
         # RESOURCE USAGE (except WAL)

--- a/roles/postgres/templates/tiny.yml
+++ b/roles/postgres/templates/tiny.yml
@@ -6,7 +6,7 @@
 # Desc      :   patroni cluster definition for {{ pg_cluster }} (tiny)
 # Path      :   /pg/bin/patroni.yml
 # Real Path :   /pg/conf/{{ pg_instance }}.yml
-# Link      :   /pg/bin/patroni.yml -> /pg/conf/{{ pg_instance}}.yml
+# Link      :   /pg/bin/patroni.yml -> /pg/conf/{{ pg_instance }}.yml
 # Note      :   Tiny Database Cluster Template (tiny:1C:1G:40GB)
 # Doc       :   https://patroni.readthedocs.io/en/latest/SETTINGS.html
 # Copyright (C) 2018-2022 Ruohang Feng
@@ -37,18 +37,27 @@ log:
 #------------------------------------------------------------------------------
 {% if pg_dcs_type == 'consul' %}
 consul:
-  host: 127.0.0.1:8500
   consistency: default         # default|consistent|stale
   register_service: true
   service_check_interval: 15s
   service_tags:
     - {{ pg_cluster }}
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+  host: 127.0.0.1:8501
+  scheme: https
+  cacert: {{ cert_homedir }}/{{ ca_file }}.crt
+{% else %}
+  host: 127.0.0.1:8500
+{% endif %}
 {% endif %}
 {% if pg_dcs_type == 'etcd' %}
 etcd:
   hosts: '{% for k,v in dcs_servers.items() %}{% if not loop.first %},{% endif %}{{ v }}:2379{% endfor %}'
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+  protocol: https
+  cacert: {{ cert_homedir }}/{{ ca_file }}.crt
 {% endif %}
-
+{% endif %}
 
 #------------------------------------------------------------------------------
 # api
@@ -63,16 +72,19 @@ restapi:
     username: {{ pg_monitor_username }}
     password: '{{ pg_monitor_password }}'
 
-
 #------------------------------------------------------------------------------
 # ctl
 #------------------------------------------------------------------------------
 ctl:
   optional:
+{% if patroni_ssl_enabled is defined and patroni_ssl_enabled|bool %}
+    insecure: false
+    cacert: '{{ cert_homedir }}/{{ ca_file }}.crt'
+    certfile: '{{ cert_homedir }}/{{ pg_instance }}.crt'
+    keyfile: '{{ cert_homedir }}/{{ pg_instance }}.key'
+{% else %}
     insecure: true
-    # cacert: '/path/to/ca/cert'
-    # certfile: '/path/to/cert/file'
-    # keyfile: '/path/to/key/file'
+{% endif %}
 
 #------------------------------------------------------------------------------
 # tags
@@ -233,6 +245,12 @@ bootstrap:
         # max_replication_slots: 16             # 10 -> 16
         wal_keep_size: 1GB                      # keep at least 1GB WAL
         password_encryption: md5                # use traditional md5 auth
+{% if pg_sslmode != 'disable' %}
+        ssl: on
+        ssl_cert_file: '{{ cert_homedir }}/{{ pg_cluster }}.crt'
+        ssl_key_file: '{{ cert_homedir }}/{{ pg_cluster }}.key'
+        ssl_ca_file: '{{ cert_homedir }}/{{ ca_file }}.crt'
+{% endif %}
 
         #----------------------------------------------------------------------
         # RESOURCE USAGE (except WAL)

--- a/roles/prometheus/templates/prometheus.yml.j2
+++ b/roles/prometheus/templates/prometheus.yml.j2
@@ -79,7 +79,15 @@ scrape_configs:
     metrics_path: /v1/agent/metrics
     params:
       format: ['prometheus']
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+    static_configs: [ { targets: [ 127.0.0.1:8501 ] , labels: { ip: {{ inventory_hostname }}, type: consul , job: infra } } ]
+    scheme: https
+    tls_config:
+      ca_file: {{ cert_homedir }}/{{ ca_file }}.crt
+      insecure_skip_verify: true
+{% else %}
     static_configs: [ { targets: [ 127.0.0.1:8500 ] , labels: { ip: {{ inventory_hostname }}, type: consul , job: infra } } ]
+{% endif %}
 {% endif %}
 
 {% if etcd_enabled|bool and dcs_servers|length > 0 %}
@@ -89,6 +97,12 @@ scrape_configs:
 {% for name,ip in dcs_servers.items() %}
       - { targets: [ {{ ip }}:2379 ] , labels: { ip: {{ ip }}, ins: {{ name }}, type: etcd , job: infra } }
 {% endfor %}
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+    scheme: https
+    tls_config:
+      ca_file: {{ cert_homedir }}/{{ ca_file }}.crt
+      insecure_skip_verify: true
+{% endif %}
 {% endif %}
 
   #------------------------------------------------------------------------------

--- a/roles/service/templates/vip-manager.yml.j2
+++ b/roles/service/templates/vip-manager.yml.j2
@@ -24,17 +24,24 @@ hosting-type: basic
 
 
 # dcs
-dcs-type: {{ pg_dcs_type|default('consul') }}
+dcs-type: {{ pg_dcs_type }}
 
 # a list that contains all DCS endpoints to which vip-manager could talk.
 dcs-endpoints:
 {% if pg_dcs_type == 'consul' %}
-  - http://127.0.0.1:8500        # consul
+  - http://127.0.0.1:8500
 {% endif %}
 {% if pg_dcs_type == 'etcd' %}
+{% if dcs_ssl_enabled is defined and dcs_ssl_enabled|bool %}
+{% for k,v in dcs_servers.items() %}
+  - https://{{ v }}:2379
+{% endfor %}
+{% else %}
 {% for k,v in dcs_servers.items() %}
   - http://{{ v }}:2379
 {% endfor %}
+etcd-ca-file: "{{ cert_homedir }}/{{ ca_file }}.crt"
+{% endif %}
 {% endif %}
 
 


### PR DESCRIPTION
The goal is to evolve the current ca implementation, automating the creation of infra nodes certificates & private keys.
Furthermore, add SSL support for both consul/etcd, Patroni, PostgreSQL and pgBouncer.

### CA & Certs
For this purpose, I moved the 'ca' role to node-init group, as all hosts will be used.
The Variable **_ca_homedir_** will be renamed to **_cert_homedir_**, **_ca_file_** will be the ca filename without extension and **_ca_cn_** will be the common name.
Also, I added two more variables:
1. **_ca_validity_**: sets the validity of the certification authority, default is 20 years;
2. **_cert_validity_**: sets the validity of the signed certs, default is 10 years.

About certs:
1. The nodes certificate will have a custom subject_alt_name to make dcs's verify_hostname working correctly;
2. The shared meta cert and the pg cluster cert will be used to secure PostgreSQL service (based on the **_pg_cluster_** var) and will be shared between cluster nodes; this point is mandatory because Patroni will retain the primary's cert filename on standbys, thus all nodes must have the same cert/privatekey filename.

Lastly, the new 'dcs' system group (controlled by **_dcs_gid_** variable) is essential because:
1. It will be the new secondary group of consul/etcd/postgres system users;
2. It will make cert & private key readable by these services (they will be chown'd root:dcs and chmod'd 640, disallowing any access to world);
3. Only ca cert will be readable to world.

### DCS
- **Consul**: The main issue I've met is that vip-manager cannot be configured to talk in ssl mode with consul. As a workaround, I enabled both HTTP and HTTPS ports and leaved vip-manager in HTTP mode;
- **etcd**: Currently, client-to-server communication and server-to-server / cluster communication (Peer) use the same cert.

### Patroni
Patroni communications will be secured when **_patroni_ssl_enabled_** is true

### Postgres & PgBouncer
SSL mode is controlled by **_pg_sslmode_** variable ( when != disabled, it enables ssl mode). Currenly, only 'require' mode has been tested. 'verify-full' will (maybe) require further testing.
Also, when using **_pg_sslmode_**, remember to change 'host' to 'hostssl' in **_pg_hba_rules_** and **_pg_hba_rules_extra_**.