### PR TITLE
Fix slight issue on ca logic and fix erroneously hba roles

### DIFF
--- a/roles/ca/tasks/main.yml
+++ b/roles/ca/tasks/main.yml
@@ -33,13 +33,22 @@
 #--------------------------------------------------------------------------
 # create or reuse ca
 #--------------------------------------------------------------------------
+# if ca_method = create and keypair exists, allow temporarily world access
+- name: Allow temporarily ca access
+  tags: ca_reuse
+  when: (ca_crt_exists.stat.exists and ca_key_exists.stat.exists) and ca_method == 'create'
+  file: path={{ item }} mode=0644
+  with_items:
+    - "{{ cert_homedir }}/{{ ca_file }}.crt"
+    - "{{ cert_homedir }}/{{ ca_file }}.key"
+
 # if ca_method = create, create a self-signed ca keypair if not exists
 # if ca_method = recreate, force recreate a self-signed ca keypair even if already exists
 - name: Create CA certificate
   tags: ca_create
   when: not (ca_crt_exists.stat.exists and ca_key_exists.stat.exists) or ca_method == 'recreate'
   block:
-    - name: Remove existing ca folders
+    - name: Remove existing cert dir
       file: path="{{ cert_homedir }}" state=absent
 
     - name: Create certs directory

--- a/roles/postgres/templates/pg_hba.conf.j2
+++ b/roles/postgres/templates/pg_hba.conf.j2
@@ -12,9 +12,9 @@ local   all             all                                    md5
 local   replication     {{ pg_replication_username }}                              md5
 {% if pg_sslmode != 'disable' %}
 hostssl replication     {{ pg_replication_username }}         127.0.0.1/32         md5
-hostssl all             {{ pg_replication_username }}         10.0.0.0/8           md5
-hostssl all             {{ pg_replication_username }}         172.16.0.0/12        md5
-hostssl all             {{ pg_replication_username }}         192.168.0.0/16       md5
+hostssl postgres        {{ pg_replication_username }}         10.0.0.0/8           md5
+hostssl postgres        {{ pg_replication_username }}         172.16.0.0/12        md5
+hostssl postgres        {{ pg_replication_username }}         192.168.0.0/16       md5
 hostssl replication     {{ pg_replication_username }}         10.0.0.0/8           md5
 hostssl replication     {{ pg_replication_username }}         172.16.0.0/12        md5
 hostssl replication     {{ pg_replication_username }}         192.168.0.0/16       md5

--- a/roles/postgres/templates/pgb_hba.conf.j2
+++ b/roles/postgres/templates/pgb_hba.conf.j2
@@ -5,34 +5,34 @@
 local     pgbouncer    postgres                                    peer
 
 # local all password access (for biz user test)
-local     all          all                                         scram-sha-256
+local     all          all                                         md5
 {% if pg_sslmode != 'disable' %}
-hostssl   all          all                         127.0.0.1/32    scram-sha-256
+hostssl   all          all                         127.0.0.1/32    md5
 
 # monitor user intranet access to pgbouncer stats
-hostssl   pgbouncer    {{ pg_monitor_username }}   10.0.0.0/8      scram-sha-256
-hostssl   pgbouncer    {{ pg_monitor_username }}   172.16.0.0/12   scram-sha-256
-hostssl   pgbouncer    {{ pg_monitor_username }}   192.168.0.0/16  scram-sha-256
+hostssl   pgbouncer    {{ pg_monitor_username }}   10.0.0.0/8      md5
+hostssl   pgbouncer    {{ pg_monitor_username }}   172.16.0.0/12   md5
+hostssl   pgbouncer    {{ pg_monitor_username }}   192.168.0.0/16  md5
 hostssl   all          {{ pg_monitor_username }}   0.0.0.0/0       reject
 
 # admin user have intranet access to pgbouncer admin
-hostssl   pgbouncer    {{ pg_admin_username }}     10.0.0.0/8      scram-sha-256
-hostssl   pgbouncer    {{ pg_admin_username }}     172.16.0.0/12   scram-sha-256
-hostssl   pgbouncer    {{ pg_admin_username }}     192.168.0.0/16  scram-sha-256
+hostssl   pgbouncer    {{ pg_admin_username }}     10.0.0.0/8      md5
+hostssl   pgbouncer    {{ pg_admin_username }}     172.16.0.0/12   md5
+hostssl   pgbouncer    {{ pg_admin_username }}     192.168.0.0/16  md5
 hostssl   all          {{ pg_admin_username }}     0.0.0.0/0       reject
 {% else %}
-host      all          all                         127.0.0.1/32    scram-sha-256
+host      all          all                         127.0.0.1/32    md5
 
 # monitor user intranet access to pgbouncer stats
-host      pgbouncer    {{ pg_monitor_username }}   10.0.0.0/8      scram-sha-256
-host      pgbouncer    {{ pg_monitor_username }}   172.16.0.0/12   scram-sha-256
-host      pgbouncer    {{ pg_monitor_username }}   192.168.0.0/16  scram-sha-256
+host      pgbouncer    {{ pg_monitor_username }}   10.0.0.0/8      md5
+host      pgbouncer    {{ pg_monitor_username }}   172.16.0.0/12   md5
+host      pgbouncer    {{ pg_monitor_username }}   192.168.0.0/16  md5
 host      all          {{ pg_monitor_username }}   0.0.0.0/0       reject
 
 # admin user have intranet access to pgbouncer admin
-host      pgbouncer    {{ pg_admin_username }}     10.0.0.0/8      scram-sha-256
-host      pgbouncer    {{ pg_admin_username }}     172.16.0.0/12   scram-sha-256
-host      pgbouncer    {{ pg_admin_username }}     192.168.0.0/16  scram-sha-256
+host      pgbouncer    {{ pg_admin_username }}     10.0.0.0/8      md5
+host      pgbouncer    {{ pg_admin_username }}     172.16.0.0/12   md5
+host      pgbouncer    {{ pg_admin_username }}     192.168.0.0/16  md5
 host      all          {{ pg_admin_username }}     0.0.0.0/0       reject
 {% endif %}
 


### PR DESCRIPTION
Three minor fixes:
1. **_pg_replication_username_** user should only be able to connect to **postgres** & **replication**, **all** isn't needed;
2. pgBouncer's hba roles got erroneously scram-sha-256 method, which is not implemented yet;
3. Fixes 'access denied' when ca keypair already exists and ca_method = 'create'.