### PR TITLE
Changed local path to pg private key during pg_key_exists registration.

### DIFF
--- a/roles/pgsql/tasks/cert.yml
+++ b/roles/pgsql/tasks/cert.yml
@@ -9,7 +9,7 @@
     # check pg sever private key on primary instance
     - name: check if pg private key exists
       delegate_to: localhost
-      stat: path=files/pki/pg/{{ pg_cluster }}.key
+      stat: path=files/pki/pgsql/{{ pg_cluster }}.key
       register: pg_key_exists
 
     # try to fetch private key from primary instance


### PR DESCRIPTION
Adjusted the path to the key during the initial registration because it is different than the other local paths in the same file.