### PR TITLE
chore: update DEFAULT_NO_PROXY item

### DIFF
--- a/configure
+++ b/configure
@@ -33,7 +33,7 @@ MODE=""                           # default install mode (el7|el8|el9|demo|sec|c
 SPEC=tiny                         # default postgres spec (tiny|mini|small|medium|large|huge)
 REGION=""                         # default region (default|china|europe)
 USE_PROXY=false                   # use global env http_proxy, https_proxy, all_proxy, no_proxy
-DEFAULT_NO_PROXY="localhost,127.0.0.1,10.0.0.0/8,192.168.0.0/16,*.pigsty,*.aliyun.com,mirrors.*,*.myqcloud.com,*.tsinghua.edu.cn"
+DEFAULT_NO_PROXY="localhost,127.0.0.1,10.0.0.0/8,192.168.0.0/16,*.pigsty,*.aliyun.com,mirrors.*,mirror.*,*.myqcloud.com,*.tsinghua.edu.cn,*.fedoraproject.org"
 
 
 #--------------------------------------------------------------#


### PR DESCRIPTION
add:
- `mirror.*`
- `*.fedoraproject.org`

经测试：
- `fedoraproject.org` 域名国内可以正常访问 
- `dl.fedoraproject.org` 在国内直接下载速度有 5MB/s 左右
- `download.fedoraproject.org` 下载会动态指向镜像站点，比如 `https://mirror.nyist.edu.cn`

