### PR TITLE
Update redis.yml

### DIFF
--- a/redis.yml
+++ b/redis.yml
@@ -116,7 +116,8 @@
               #!/bin/bash
               {% for i in redis_meta %}
               {% for port, _ in i.redis_instances.items() %}
-              cat /tmp/{{ redis_cluster }}.monitor | redis-cli -h {{ i.inventory_hostname }} -p {{ port }} -a {{ i.redis_password|default('') }}
+              # cat /tmp/{{ redis_cluster }}.monitor | redis-cli -h {{ i.inventory_hostname }} -p {{ port }} -a {{ i.redis_password|default('') }}
+              cat /tmp/{{ redis_cluster }}.monitor | redis-cli -h {{ i.inventory_hostname }} -p {{ port }} {% if i.redis_password is defined and i.redis_password %}-a {{ i.redis_password }}{% endif %}
               {% endfor %}
               {% endfor %}
           vars: { cluster_query: "[@.*][0][?redis_cluster=='{{ redis_cluster }}']" }


### PR DESCRIPTION
If there is no password, the monitoring command does not need the `-a` parameter either.