### PR TITLE
fix(supabase): use S3_REGION env var for storage s3 config

### DIFF
--- a/app/supabase/docker-compose.yml
+++ b/app/supabase/docker-compose.yml
@@ -237,7 +237,7 @@ services:
       DATABASE_URL: postgres://supabase_storage_admin:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
       FILE_SIZE_LIMIT: 52428800
       TENANT_ID: stub
-      REGION: stub
+      REGION: ${S3_REGION}
       ENABLE_IMAGE_TRANSFORMATION: "true"
       IMGPROXY_URL: http://imgproxy:5001
 


### PR DESCRIPTION
now the storage service use `stub` as s3 region