### PR TITLE
grafana datasource uids cannot have a dot

### DIFF
--- a/roles/pg_exporters/tasks/register_grafana.yml
+++ b/roles/pg_exporters/tasks/register_grafana.yml
@@ -45,7 +45,7 @@
           }
         mode: 0600
       vars:
-        name: "{{ pg_cluster }}-{{ pg_seq }}.{{ database.name }}"
+        name: "{{ pg_cluster }}-{{ pg_seq }}-{{ database.name }}"
         host: "{{ pg_host }}"
         port: "{{ pg_port|default(5432) }}"
         username: "{{ pg_monitor_username|default('dbuser_monitor') }}"
@@ -67,7 +67,7 @@
         curl -X POST   "{{ endpoint }}/api/datasources/" -u "{{ username }}:{{ password }}" -H 'Content-Type: application/json' -d @/etc/pigsty/datasources/{{ name }}.json
       args: { executable: /bin/bash }
       vars:
-        name: "{{ pg_cluster }}-{{ pg_seq }}.{{ database.name }}"
+        name: "{{ pg_cluster }}-{{ pg_seq }}-{{ database.name }}"
         endpoint: "{{ 'http://' +  infra_portal.grafana.endpoint|default('${admin_ip}:3000')|replace('${admin_ip}', admin_ip) }}"
         username: "{{ grafana_admin_username|default('admin') }}"
         password: "{{ grafana_admin_password|default('pigsty') }}"

--- a/roles/pg_monitor/tasks/register_grafana.yml
+++ b/roles/pg_monitor/tasks/register_grafana.yml
@@ -46,7 +46,7 @@
           }
         mode: 0600
       vars:
-        name: "{{ pg_cluster }}-{{ pg_seq }}.{{ database.name }}"
+        name: "{{ pg_cluster }}-{{ pg_seq }}-{{ database.name }}"
         host: "{{ inventory_hostname }}"
         port: "{{ pg_port|default(5432) }}"
         username: "{{ pg_monitor_username|default('dbuser_monitor') }}"
@@ -64,7 +64,7 @@
         curl -X POST   "{{ endpoint }}/api/datasources/" -u "{{ username }}:{{ password }}" -H 'Content-Type: application/json' -d @/etc/pigsty/datasources/{{ name }}.json
       args: { executable: /bin/bash }
       vars:
-        name: "{{ pg_cluster }}-{{ pg_seq }}.{{ database.name }}"
+        name: "{{ pg_cluster }}-{{ pg_seq }}-{{ database.name }}"
         endpoint: "{{ 'http://' +  infra_portal.grafana.endpoint|default('${admin_ip}:3000')|replace('${admin_ip}', admin_ip) }}"
         username: "{{ grafana_admin_username|default('admin') }}"
         password: "{{ grafana_admin_password|default('pigsty') }}"


### PR DESCRIPTION
It appears that Grafana datasource uids cannot contain "."

Updating the name variable to fix.... and register_grafana.yml now creates my pg datasources automatically.