### PR TITLE
fix: use fully qualified table names in copy-progress script

### DIFF
--- a/roles/pg_migration/templates/copy-progress
+++ b/roles/pg_migration/templates/copy-progress
@@ -59,7 +59,7 @@ function relation_progress() {
 
 
 function overall_progress() {
-  tables=$(psql ${DSTPG} -AXtwc "SELECT relname FROM pg_class c JOIN pg_subscription_rel sr ON c.oid = sr.srrelid WHERE relkind = 'r' AND srsubstate != 'r';")
+  tables=$(psql ${DSTPG} -AXtwc "SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS name FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid JOIN pg_subscription_rel sr ON c.oid = sr.srrelid WHERE c.relkind = 'r' AND sr.srsubstate != 'r';")
   for table in $tables; do
     relation_progress ${table}
   done


### PR DESCRIPTION
Like https://github.com/pgsty/pigsty/blob/363462a6f193e43dc9c9681c30eefd2561e59696/roles/pg_migration/templates/copy-diff#L74, the fully qualified table names should be used in `copy-progress`. Otherwise, tables not in `search_path` or tables that share the same `relname` may not be correctly displayed.