### PR TITLE
Fix typo of 'PostgresIdleInXact' alert

### DIFF
--- a/files/victoria/rules/pgsql.yml
+++ b/files/victoria/rules/pgsql.yml
@@ -1585,12 +1585,12 @@ groups:
             pg:db:conn_usage[ins={{ $labels.ins }}, instance={{ $labels.instance }}, datname={{ $labels.datname }}] = {{ $value | printf "%.3f" }} > 0.70
 
       # database connection usage > 70%
-      - alert: PostgresIdleInXact
+      - alert: PostgresConnUsageHigh
         expr: pg:db:ixact_backends > 1
         for: 3m
         labels: { level: 2, severity: INFO, category: pgsql }
         annotations:
-          summary: "Info PostgresIdleInXact: {{ $labels.ins }}@{{ $labels.instance }} [{{ $labels.datname }}]"
+          summary: "Info PostgresConnUsageHigh: {{ $labels.ins }}@{{ $labels.instance }} [{{ $labels.datname }}]"
           description: |
             pg:db:ixact_backends[ins={{ $labels.ins }}, instance={{ $labels.instance }}, datname={{ $labels.datname }}] = {{ $value | printf "%.0f" }} > 1
 


### PR DESCRIPTION
The alert command for database connection usage > 70% is now changed from `PostgresIdleInXact` to `PostgresConnUsageHigh`.

Closes #681 